### PR TITLE
refactor: tighten doc:embed code-fence regex and simplify fence counting

### DIFF
--- a/scripts/cmd/embed-examples.mts
+++ b/scripts/cmd/embed-examples.mts
@@ -10,10 +10,14 @@ const codeBlockEnd = '```';
 
 /**
  * Matches the opening line of a fenced code block whose language tag is exactly
- * `ts`, `tsx`, or `js`. The trailing `(?!\w)` negative lookahead prevents the
- * pattern from also prefix-matching languages such as `jsx` or `typescript`.
+ * `ts`, `tsx`, or `js` (optionally followed by an info string). The `(?=\s|$)`
+ * lookahead requires the tag to end at whitespace or end-of-line, so fences such
+ * as ```jsx, ```typescript, or ```ts-ignore are not matched.
  */
-const codeBlockStartRegex = /^```(?:tsx|ts|js)(?!\w)/mu;
+const codeBlockStartRegex = /^```(?:tsx|ts|js)(?=\s|$)/mu;
+
+/** Global counterpart of {@link codeBlockStartRegex} for counting all fences. */
+const codeBlockStartRegexGlobal = new RegExp(codeBlockStartRegex, 'gmu');
 
 const documents: DeepReadonly<
   {
@@ -47,8 +51,9 @@ export const embedExamples = async (): Promise<Result<undefined, unknown>> => {
       // eslint-disable-next-line security/detect-non-literal-fs-filename
       const markdownContent = await fs.readFile(mdPath, 'utf8');
 
-      const codeBlockCount =
-        markdownContent.split(codeBlockStartRegex).length - 1;
+      const codeBlockCount = (
+        markdownContent.match(codeBlockStartRegexGlobal) ?? []
+      ).length;
 
       if (codeBlockCount !== sampleCodeFiles.length) {
         return Result.err(


### PR DESCRIPTION
Follow-up to the merged `chore: update doc:embed scripts` PR, addressing the Copilot review comments on the `doc:embed` script.

- Require the code-fence language tag to end at whitespace or end-of-line so only exact `ts`/`tsx`/`js` tags match (excludes `ts-ignore`, `jsx`, `typescript`, etc.). The JSDoc is updated to describe the actual behavior.
- Count fences with a global regex derived from the shared pattern instead of `String.split`, avoiding intermediate substring allocation and breakage if a capturing group is added later.

Verified: `tsc`, `eslint`, and `prettier` pass, and `doc:embed` produces no change to the embedded markdown (behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
