### PR TITLE
fix: quote absolute paths in build.mts shell command strings

### DIFF
--- a/scripts/cmd/build.mts
+++ b/scripts/cmd/build.mts
@@ -60,7 +60,7 @@ const build = async (skipCheck: boolean): Promise<void> => {
     await logStep({
       startMessage: 'Running type checking',
       action: () =>
-        runCmdStep(`node ${nativeTsc} --noEmit`, 'Type checking failed'),
+        runCmdStep(`node "${nativeTsc}" --noEmit`, 'Type checking failed'),
       successMessage: 'Type checking passed',
     });
   }
@@ -104,7 +104,7 @@ const build = async (skipCheck: boolean): Promise<void> => {
     startMessage: 'Generating type declarations',
     action: () =>
       runCmdStep(
-        `node ${nativeTsc} -p ${path.resolve(projectRootPath, './configs/tsconfig.build.json')} --emitDeclarationOnly`,
+        `node "${nativeTsc}" -p "${path.resolve(projectRootPath, './configs/tsconfig.build.json')}" --emitDeclarationOnly`,
         'Type declaration generation failed',
       ),
     successMessage: 'Type declarations generated',


### PR DESCRIPTION
## Summary
Follow-up to #413 addressing review feedback that landed after that PR merged (the review comments were posted at nearly the same moment auto-merge fired). `runCmdStep` passes commands through `$`, a shell-exec wrapper, so interpolating the unquoted absolute `nativeTsc` path (and the resolved tsconfig path passed to `--emitDeclarationOnly`) can break the build when the repo checkout path contains spaces.

## Test plan
- [x] `pnpm run build` passes with the quoted paths


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZXTnGfYFgqbbEgYxRycrG)_