### PR TITLE
ci: rename deprecated app-id input to client-id

### DIFF
--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -26,7 +26,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.DEPENDABOT_AUTO_MERGE_BOT_APP_ID }}
+          client-id: ${{ vars.DEPENDABOT_AUTO_MERGE_BOT_APP_ID }}
           private-key: ${{ secrets.DEPENDABOT_AUTO_MERGE_BOT_PRIVATE_KEY }}
 
       - name: Checkout


### PR DESCRIPTION
## What

Rename the deprecated `app-id` input to `client-id` in the
`actions/create-github-app-token` steps.

## Why

The action deprecated `app-id` (`deprecationMessage: "Use 'client-id' instead."`),
emitting a warning on every run. The input value is forwarded as the GitHub App
JWT issuer, and GitHub still accepts the numeric App ID as the issuer — so the
existing `vars.*_APP_ID` value keeps working with no org-variable changes. This
mirrors the setup already in place in `ts-repo-utils`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
