### PR TITLE
feat(array)!: brand Arr.isEmpty/isNonEmpty and add prefer-canonical-length-guard

### DIFF
--- a/.changeset/brand-is-empty-guard.md
+++ b/.changeset/brand-is-empty-guard.md
@@ -27,3 +27,14 @@ and `isMinLengthArray(xs, 1)` are now the _type-identical_ rewrites, and the
 structural `*Tuple` guards (`isFixedLengthTuple(xs, 0)`, `isMaxLengthTuple(xs, 0)`,
 `isBoundedLengthTuple(xs, 0, 0)`, `isMinLengthTuple(xs, 1)`) are rewritten too —
 those strengthen the narrowed type by adding the brand.
+
+`prefer-canonical-length-guard` additionally absorbs the five `xs.length <op> n`
+comparison rules — `prefer-arr-is-non-empty`, `prefer-arr-is-min-length-array`,
+`prefer-arr-is-max-length-array`, `prefer-arr-is-bounded-length-array` and
+`prefer-arr-is-fixed-length-array` — so one rule now covers both
+comparison → guard and guard → guard normalization.
+
+BREAKING CHANGE: those five rule names are removed from the plugin; enable
+`ts-data-forge/prefer-canonical-length-guard` instead. Their behavior is
+unchanged — the rule reuses their implementations rather than reimplementing
+them.

--- a/.changeset/brand-is-empty-guard.md
+++ b/.changeset/brand-is-empty-guard.md
@@ -1,0 +1,29 @@
+---
+'ts-data-forge': major
+'eslint-plugin-ts-data-forge': minor
+---
+
+**`Arr.isEmpty` and `Arr.isNonEmpty` now narrow to the branded length-constrained
+array types**, matching the rest of the `Arr` length-guard family.
+
+| guard                | before             | after                         |
+| :------------------- | :----------------- | :---------------------------- |
+| `Arr.isEmpty(xs)`    | `readonly []`      | `FixedLengthArray<0, E> & Xs` |
+| `Arr.isNonEmpty(xs)` | `NonEmptyArray<E>` | `MinLengthArray<1, E> & Xs`   |
+
+`isEmpty` was missing the brand entirely, so it was not equivalent to
+`Arr.isFixedLengthArray(xs, 0)`; `isNonEmpty` had the brand but dropped the input
+type instead of intersecting with it the way `Arr.isMinLengthArray` does. Both
+now behave exactly like their `is*LengthArray` counterparts.
+
+BREAKING CHANGE: the narrowed types are strictly narrower than before. Code that
+reads the narrowed value keeps compiling, but an explicit annotation such as
+`const empty: readonly [] = xs` after the guard, or passing the narrowed value
+where an unbranded array literal is expected, may now need the unbranded type
+spelled out.
+
+`prefer-canonical-length-guard` follows the new semantics: `isFixedLengthArray(xs, 0)`
+and `isMinLengthArray(xs, 1)` are now the _type-identical_ rewrites, and the
+structural `*Tuple` guards (`isFixedLengthTuple(xs, 0)`, `isMaxLengthTuple(xs, 0)`,
+`isBoundedLengthTuple(xs, 0, 0)`, `isMinLengthTuple(xs, 1)`) are rewritten too —
+those strengthen the narrowed type by adding the brand.

--- a/.changeset/prefer-canonical-length-guard.md
+++ b/.changeset/prefer-canonical-length-guard.md
@@ -1,0 +1,13 @@
+---
+'eslint-plugin-ts-data-forge': minor
+---
+
+Add the `prefer-canonical-length-guard` rule, which normalizes degenerate `Arr`
+length guards to their canonical spelling:
+
+- `Arr.isFixedLengthTuple(xs, 0)`, `Arr.isMaxLengthTuple(xs, 0)` and
+  `Arr.isBoundedLengthTuple(xs, 0, 0)` → `Arr.isEmpty(xs)`
+- `Arr.isMinLengthArray(xs, 1)` → `Arr.isNonEmpty(xs)`
+
+Every rewrite narrows to exactly the same type, so the autofix is
+type-preserving.

--- a/packages/eslint-plugin-ts-data-forge/README.md
+++ b/packages/eslint-plugin-ts-data-forge/README.md
@@ -23,7 +23,7 @@ export default [
     {
         plugins: { 'ts-data-forge': eslintPluginTsDataForge },
         rules: {
-            'ts-data-forge/prefer-arr-is-non-empty': 'error',
+            'ts-data-forge/prefer-canonical-length-guard': 'error',
             'ts-data-forge/prefer-is-record-and-has-key': 'error',
             // ...enable the rules you want
         } satisfies Partial<EslintTsDataForgeRules>,
@@ -33,25 +33,20 @@ export default [
 
 ## Rules
 
-| Rule                                   | Description                                                                            |
-| -------------------------------------- | -------------------------------------------------------------------------------------- |
-| `prefer-canonical-array-slicing`       | Unify non-mutating array add/remove patterns into `Arr.tail`/`skip`/`take`/etc.        |
-| `prefer-canonical-length-guard`        | Normalize degenerate length guards (`Arr.isFixedLengthTuple(xs, 0)`) to `Arr.isEmpty`. |
-| `prefer-arr-is-min-length-array`       | Replace `xs.length >= n` with `Arr.isMinLengthArray(xs, n)`.                           |
-| `prefer-arr-is-max-length-array`       | Replace `xs.length <= n` with `Arr.isMaxLengthArray(xs, n)`.                           |
-| `prefer-arr-is-bounded-length-array`   | Replace `xs.length >= min && xs.length <= max` with `Arr.isBoundedLengthArray(…)`.     |
-| `prefer-arr-is-fixed-length-array`     | Replace `xs.length === n` with `Arr.isFixedLengthArray(xs, n)`.                        |
-| `prefer-arr-is-array`                  | Replace `Array.isArray` with `Arr.isArray`.                                            |
-| `prefer-arr-is-non-empty`              | Replace `xs.length > 0` with `Arr.isNonEmpty(xs)`.                                     |
-| `prefer-arr-sum`                       | Replace `xs.reduce((a, b) => a + b, 0)` with `Arr.sum(xs)` / `Arr.sumBy(xs, fn)`.      |
-| `prefer-as-int`                        | Replace branded-number assertions (`x as Int`) with `asInt(x)`-style casts.            |
-| `prefer-is-non-null-object`            | Replace `typeof u === 'object' && u !== null` with `isNonNullObject(u)`.               |
-| `prefer-range-for-loop`                | Replace C-style `for` loops with `for (const i of range(begin, end))`.                 |
-| `prefer-is-record-and-has-key`         | Replace `Object.hasOwn(obj, key)` / `key in obj` with `isRecord(obj) && hasKey(…)`.    |
-| `prefer-num-safe-parse-int`            | Replace `parseInt(x, 10)` with `Result.unwrapOkOr(Num.safeParseInt(x), NaN)`.          |
-| `prefer-num-safe-parse-float`          | Replace `parseFloat(x)` / `Number(x)` with `Num.safeParseFloat`-based parsing.         |
-| `no-unnecessary-type-guard`            | Flag `ts-data-forge` type-guard calls that do no narrowing (type-aware).               |
-| `prefer-comparison-over-nullish-guard` | Prefer direct `=== null` / `!== undefined` over `isNull` / `isNotUndefined` calls.     |
+| Rule                                   | Description                                                                                                                                          |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `prefer-canonical-array-slicing`       | Unify non-mutating array add/remove patterns into `Arr.tail`/`skip`/`take`/etc.                                                                      |
+| `prefer-canonical-length-guard`        | Normalize array-length checks to the canonical `Arr` guard (`xs.length > 0` → `Arr.isNonEmpty`, `Arr.isFixedLengthTuple(xs, 0)` → `Arr.isEmpty`, …). |
+| `prefer-arr-is-array`                  | Replace `Array.isArray` with `Arr.isArray`.                                                                                                          |
+| `prefer-arr-sum`                       | Replace `xs.reduce((a, b) => a + b, 0)` with `Arr.sum(xs)` / `Arr.sumBy(xs, fn)`.                                                                    |
+| `prefer-as-int`                        | Replace branded-number assertions (`x as Int`) with `asInt(x)`-style casts.                                                                          |
+| `prefer-is-non-null-object`            | Replace `typeof u === 'object' && u !== null` with `isNonNullObject(u)`.                                                                             |
+| `prefer-range-for-loop`                | Replace C-style `for` loops with `for (const i of range(begin, end))`.                                                                               |
+| `prefer-is-record-and-has-key`         | Replace `Object.hasOwn(obj, key)` / `key in obj` with `isRecord(obj) && hasKey(…)`.                                                                  |
+| `prefer-num-safe-parse-int`            | Replace `parseInt(x, 10)` with `Result.unwrapOkOr(Num.safeParseInt(x), NaN)`.                                                                        |
+| `prefer-num-safe-parse-float`          | Replace `parseFloat(x)` / `Number(x)` with `Num.safeParseFloat`-based parsing.                                                                       |
+| `no-unnecessary-type-guard`            | Flag `ts-data-forge` type-guard calls that do no narrowing (type-aware).                                                                             |
+| `prefer-comparison-over-nullish-guard` | Prefer direct `=== null` / `!== undefined` over `isNull` / `isNotUndefined` calls.                                                                   |
 
 ## License
 

--- a/packages/eslint-plugin-ts-data-forge/README.md
+++ b/packages/eslint-plugin-ts-data-forge/README.md
@@ -33,24 +33,25 @@ export default [
 
 ## Rules
 
-| Rule                                   | Description                                                                         |
-| -------------------------------------- | ----------------------------------------------------------------------------------- |
-| `prefer-canonical-array-slicing`       | Unify non-mutating array add/remove patterns into `Arr.tail`/`skip`/`take`/etc.     |
-| `prefer-arr-is-min-length-array`       | Replace `xs.length >= n` with `Arr.isMinLengthArray(xs, n)`.                        |
-| `prefer-arr-is-max-length-array`       | Replace `xs.length <= n` with `Arr.isMaxLengthArray(xs, n)`.                        |
-| `prefer-arr-is-bounded-length-array`   | Replace `xs.length >= min && xs.length <= max` with `Arr.isBoundedLengthArray(…)`.  |
-| `prefer-arr-is-fixed-length-array`     | Replace `xs.length === n` with `Arr.isFixedLengthArray(xs, n)`.                     |
-| `prefer-arr-is-array`                  | Replace `Array.isArray` with `Arr.isArray`.                                         |
-| `prefer-arr-is-non-empty`              | Replace `xs.length > 0` with `Arr.isNonEmpty(xs)`.                                  |
-| `prefer-arr-sum`                       | Replace `xs.reduce((a, b) => a + b, 0)` with `Arr.sum(xs)` / `Arr.sumBy(xs, fn)`.   |
-| `prefer-as-int`                        | Replace branded-number assertions (`x as Int`) with `asInt(x)`-style casts.         |
-| `prefer-is-non-null-object`            | Replace `typeof u === 'object' && u !== null` with `isNonNullObject(u)`.            |
-| `prefer-range-for-loop`                | Replace C-style `for` loops with `for (const i of range(begin, end))`.              |
-| `prefer-is-record-and-has-key`         | Replace `Object.hasOwn(obj, key)` / `key in obj` with `isRecord(obj) && hasKey(…)`. |
-| `prefer-num-safe-parse-int`            | Replace `parseInt(x, 10)` with `Result.unwrapOkOr(Num.safeParseInt(x), NaN)`.       |
-| `prefer-num-safe-parse-float`          | Replace `parseFloat(x)` / `Number(x)` with `Num.safeParseFloat`-based parsing.      |
-| `no-unnecessary-type-guard`            | Flag `ts-data-forge` type-guard calls that do no narrowing (type-aware).            |
-| `prefer-comparison-over-nullish-guard` | Prefer direct `=== null` / `!== undefined` over `isNull` / `isNotUndefined` calls.  |
+| Rule                                   | Description                                                                            |
+| -------------------------------------- | -------------------------------------------------------------------------------------- |
+| `prefer-canonical-array-slicing`       | Unify non-mutating array add/remove patterns into `Arr.tail`/`skip`/`take`/etc.        |
+| `prefer-canonical-length-guard`        | Normalize degenerate length guards (`Arr.isFixedLengthTuple(xs, 0)`) to `Arr.isEmpty`. |
+| `prefer-arr-is-min-length-array`       | Replace `xs.length >= n` with `Arr.isMinLengthArray(xs, n)`.                           |
+| `prefer-arr-is-max-length-array`       | Replace `xs.length <= n` with `Arr.isMaxLengthArray(xs, n)`.                           |
+| `prefer-arr-is-bounded-length-array`   | Replace `xs.length >= min && xs.length <= max` with `Arr.isBoundedLengthArray(…)`.     |
+| `prefer-arr-is-fixed-length-array`     | Replace `xs.length === n` with `Arr.isFixedLengthArray(xs, n)`.                        |
+| `prefer-arr-is-array`                  | Replace `Array.isArray` with `Arr.isArray`.                                            |
+| `prefer-arr-is-non-empty`              | Replace `xs.length > 0` with `Arr.isNonEmpty(xs)`.                                     |
+| `prefer-arr-sum`                       | Replace `xs.reduce((a, b) => a + b, 0)` with `Arr.sum(xs)` / `Arr.sumBy(xs, fn)`.      |
+| `prefer-as-int`                        | Replace branded-number assertions (`x as Int`) with `asInt(x)`-style casts.            |
+| `prefer-is-non-null-object`            | Replace `typeof u === 'object' && u !== null` with `isNonNullObject(u)`.               |
+| `prefer-range-for-loop`                | Replace C-style `for` loops with `for (const i of range(begin, end))`.                 |
+| `prefer-is-record-and-has-key`         | Replace `Object.hasOwn(obj, key)` / `key in obj` with `isRecord(obj) && hasKey(…)`.    |
+| `prefer-num-safe-parse-int`            | Replace `parseInt(x, 10)` with `Result.unwrapOkOr(Num.safeParseInt(x), NaN)`.          |
+| `prefer-num-safe-parse-float`          | Replace `parseFloat(x)` / `Number(x)` with `Num.safeParseFloat`-based parsing.         |
+| `no-unnecessary-type-guard`            | Flag `ts-data-forge` type-guard calls that do no narrowing (type-aware).               |
+| `prefer-comparison-over-nullish-guard` | Prefer direct `=== null` / `!== undefined` over `isNull` / `isNotUndefined` calls.     |
 
 ## License
 

--- a/packages/eslint-plugin-ts-data-forge/src/rule-types.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/rule-types.mts
@@ -43,7 +43,7 @@ namespace PreferCanonicalArraySlicing {
 }
 
 /**
- * @description Normalize degenerate `Arr` length guards (e.g. `Arr.isFixedLengthTuple(xs, 0)`) to `Arr.isEmpty` / `Arr.isNonEmpty`.
+ * @description Normalize array-length checks to their canonical `Arr` guard: `xs.length <op> n` becomes the matching `Arr.is*` guard, and degenerate guards (e.g. `Arr.isFixedLengthTuple(xs, 0)`) become `Arr.isEmpty` / `Arr.isNonEmpty`.
  *
  *  ```md
  *  | key        | value      |
@@ -54,66 +54,6 @@ namespace PreferCanonicalArraySlicing {
  *  ```
  */
 namespace PreferCanonicalLengthGuard {
-  export type RuleEntry = Linter.StringSeverity;
-}
-
-/**
- * @description Replace `xs.length >= n` with `Arr.isMinLengthArray(xs, n)` from ts-data-forge.
- *
- *  ```md
- *  | key        | value      |
- *  | :--------- | :--------- |
- *  | type       | suggestion |
- *  | deprecated | false      |
- *  | fixable    | code       |
- *  ```
- */
-namespace PreferArrIsMinLengthArray {
-  export type RuleEntry = Linter.StringSeverity;
-}
-
-/**
- * @description Replace `xs.length <= n` with `Arr.isMaxLengthArray(xs, n)` from ts-data-forge.
- *
- *  ```md
- *  | key        | value      |
- *  | :--------- | :--------- |
- *  | type       | suggestion |
- *  | deprecated | false      |
- *  | fixable    | code       |
- *  ```
- */
-namespace PreferArrIsMaxLengthArray {
-  export type RuleEntry = Linter.StringSeverity;
-}
-
-/**
- * @description Replace `xs.length >= min && xs.length <= max` with `Arr.isBoundedLengthArray(xs, min, max)` from ts-data-forge.
- *
- *  ```md
- *  | key        | value      |
- *  | :--------- | :--------- |
- *  | type       | suggestion |
- *  | deprecated | false      |
- *  | fixable    | code       |
- *  ```
- */
-namespace PreferArrIsBoundedLengthArray {
-  export type RuleEntry = Linter.StringSeverity;
-}
-
-/**
- * @description Replace `xs.length === n` with `Arr.isFixedLengthArray(xs, n)` from ts-data-forge.
- *
- *  ```md
- *  | key        | value      |
- *  | :--------- | :--------- |
- *  | type       | suggestion |
- *  | deprecated | false      |
- *  | fixable    | code       |
- *  ```
- */
-namespace PreferArrIsFixedLengthArray {
   export type RuleEntry = Linter.StringSeverity;
 }
 
@@ -129,21 +69,6 @@ namespace PreferArrIsFixedLengthArray {
  *  ```
  */
 namespace PreferArrIsArray {
-  export type RuleEntry = Linter.StringSeverity;
-}
-
-/**
- * @description Replace `xs.length > 0` with `Arr.isNonEmpty(xs)` from ts-data-forge.
- *
- *  ```md
- *  | key        | value      |
- *  | :--------- | :--------- |
- *  | type       | suggestion |
- *  | deprecated | false      |
- *  | fixable    | code       |
- *  ```
- */
-namespace PreferArrIsNonEmpty {
   export type RuleEntry = Linter.StringSeverity;
 }
 
@@ -313,12 +238,7 @@ namespace PreferComparisonOverNullishGuard {
 export type EslintTsDataForgeRules = Readonly<{
   'ts-data-forge/prefer-canonical-array-slicing': PreferCanonicalArraySlicing.RuleEntry;
   'ts-data-forge/prefer-canonical-length-guard': PreferCanonicalLengthGuard.RuleEntry;
-  'ts-data-forge/prefer-arr-is-min-length-array': PreferArrIsMinLengthArray.RuleEntry;
-  'ts-data-forge/prefer-arr-is-max-length-array': PreferArrIsMaxLengthArray.RuleEntry;
-  'ts-data-forge/prefer-arr-is-bounded-length-array': PreferArrIsBoundedLengthArray.RuleEntry;
-  'ts-data-forge/prefer-arr-is-fixed-length-array': PreferArrIsFixedLengthArray.RuleEntry;
   'ts-data-forge/prefer-arr-is-array': PreferArrIsArray.RuleEntry;
-  'ts-data-forge/prefer-arr-is-non-empty': PreferArrIsNonEmpty.RuleEntry;
   'ts-data-forge/prefer-arr-sum': PreferArrSum.RuleEntry;
   'ts-data-forge/prefer-as-int': PreferAsInt.RuleEntry;
   'ts-data-forge/prefer-is-non-null-object': PreferIsNonNullObject.RuleEntry;

--- a/packages/eslint-plugin-ts-data-forge/src/rule-types.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/rule-types.mts
@@ -43,6 +43,21 @@ namespace PreferCanonicalArraySlicing {
 }
 
 /**
+ * @description Normalize degenerate `Arr` length guards (e.g. `Arr.isFixedLengthTuple(xs, 0)`) to `Arr.isEmpty` / `Arr.isNonEmpty`.
+ *
+ *  ```md
+ *  | key        | value      |
+ *  | :--------- | :--------- |
+ *  | type       | suggestion |
+ *  | deprecated | false      |
+ *  | fixable    | code       |
+ *  ```
+ */
+namespace PreferCanonicalLengthGuard {
+  export type RuleEntry = Linter.StringSeverity;
+}
+
+/**
  * @description Replace `xs.length >= n` with `Arr.isMinLengthArray(xs, n)` from ts-data-forge.
  *
  *  ```md
@@ -297,6 +312,7 @@ namespace PreferComparisonOverNullishGuard {
 
 export type EslintTsDataForgeRules = Readonly<{
   'ts-data-forge/prefer-canonical-array-slicing': PreferCanonicalArraySlicing.RuleEntry;
+  'ts-data-forge/prefer-canonical-length-guard': PreferCanonicalLengthGuard.RuleEntry;
   'ts-data-forge/prefer-arr-is-min-length-array': PreferArrIsMinLengthArray.RuleEntry;
   'ts-data-forge/prefer-arr-is-max-length-array': PreferArrIsMaxLengthArray.RuleEntry;
   'ts-data-forge/prefer-arr-is-bounded-length-array': PreferArrIsBoundedLengthArray.RuleEntry;

--- a/packages/eslint-plugin-ts-data-forge/src/rules/prefer-canonical-length-guard.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/rules/prefer-canonical-length-guard.mts
@@ -1,0 +1,147 @@
+import {
+  AST_NODE_TYPES,
+  type TSESLint,
+  type TSESTree,
+} from '@typescript-eslint/utils';
+import { getImportedLocalName, getTsDataForgeImport } from './import-utils.mjs';
+
+type Options = readonly [];
+
+type MessageIds = 'useCanonicalGuard';
+
+/**
+ * Length guards whose bound makes them exactly equivalent to `Arr.isEmpty` /
+ * `Arr.isNonEmpty`, keyed by guard name.
+ *
+ * Every entry is *type-identical*, not merely equivalent at runtime:
+ *
+ * - `FixedLengthTuple<0, E>` / `MaxLengthTuple<0, E>` /
+ *   `BoundedLengthTuple<0, 0, E>` all resolve to `readonly []`, which is what
+ *   `isEmpty` narrows to.
+ * - `MinLengthArray<1, E>` is the definition of `NonEmptyArray<E>`, which is
+ *   what `isNonEmpty` narrows to.
+ *
+ * The branded `isFixedLengthArray(xs, 0)` is deliberately absent: it narrows to
+ * `FixedLengthArray<0, E>`, a strict subtype of `readonly []`, so rewriting it
+ * to `isEmpty` would *widen* the narrowed type and can break call sites.
+ */
+const GUARD_REWRITES = [
+  { guard: 'isFixedLengthTuple', bounds: [0], replacement: 'isEmpty' },
+  { guard: 'isMaxLengthTuple', bounds: [0], replacement: 'isEmpty' },
+  { guard: 'isBoundedLengthTuple', bounds: [0, 0], replacement: 'isEmpty' },
+  { guard: 'isMinLengthArray', bounds: [1], replacement: 'isNonEmpty' },
+] as const satisfies readonly Readonly<{
+  guard: string;
+  bounds: readonly number[];
+  replacement: string;
+}>[];
+
+export const preferCanonicalLengthGuard: TSESLint.RuleModule<
+  MessageIds,
+  Options
+> = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Normalize degenerate `Arr` length guards (e.g. `Arr.isFixedLengthTuple(xs, 0)`) to `Arr.isEmpty` / `Arr.isNonEmpty`.',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      useCanonicalGuard:
+        'Replace `{{arrName}}.{{guard}}({{boundsText}})` with `{{arrName}}.{{replacement}}(...)`: it narrows to exactly the same type.',
+    },
+  },
+
+  create: (context) => {
+    const sourceCode = context.sourceCode;
+
+    const arrLocalName = getImportedLocalName(
+      getTsDataForgeImport(sourceCode.ast),
+      'Arr',
+    );
+
+    if (arrLocalName === undefined) return {};
+
+    return {
+      CallExpression: (node) => {
+        const guardName = getGuardName(node, arrLocalName);
+
+        if (guardName === undefined) return;
+
+        const rewrite = GUARD_REWRITES.find(
+          (entry) => entry.guard === guardName,
+        );
+
+        if (rewrite === undefined || !matchesBounds(node, rewrite.bounds)) {
+          return;
+        }
+
+        const [array] = node.arguments;
+
+        if (array === undefined) return;
+
+        const arrayText = sourceCode.getText(array);
+
+        context.report({
+          node,
+          messageId: 'useCanonicalGuard',
+          data: {
+            arrName: arrLocalName,
+            guard: guardName,
+            boundsText: ['…', ...rewrite.bounds.map(String)].join(', '),
+            replacement: rewrite.replacement,
+          },
+          fix: (fixer) =>
+            fixer.replaceText(
+              node,
+              `${arrLocalName}.${rewrite.replacement}(${arrayText})`,
+            ),
+        });
+      },
+    };
+  },
+  defaultOptions: [],
+} as const;
+
+/** The `Arr.<guard>` method name of `node`, or `undefined` for other calls. */
+const getGuardName = (
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  node: TSESTree.CallExpression,
+  arrLocalName: string,
+): string | undefined => {
+  const { callee } = node;
+
+  return callee.type === AST_NODE_TYPES.MemberExpression &&
+    !callee.computed &&
+    callee.object.type === AST_NODE_TYPES.Identifier &&
+    callee.object.name === arrLocalName &&
+    callee.property.type === AST_NODE_TYPES.Identifier
+    ? callee.property.name
+    : undefined;
+};
+
+/**
+ * Whether the call is `guard(array, ...bounds)` with every bound written as the
+ * exact numeric literal the rewrite requires.
+ */
+const matchesBounds = (
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  node: TSESTree.CallExpression,
+  bounds: readonly number[],
+): boolean => {
+  const args = node.arguments;
+
+  if (args.length !== bounds.length + 1 || node.typeArguments !== undefined) {
+    return false;
+  }
+
+  return args.every(
+    (arg, index) =>
+      arg.type !== AST_NODE_TYPES.SpreadElement &&
+      (index === 0 ||
+        (arg.type === AST_NODE_TYPES.Literal &&
+          arg.value === bounds[index - 1])),
+  );
+};

--- a/packages/eslint-plugin-ts-data-forge/src/rules/prefer-canonical-length-guard.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/rules/prefer-canonical-length-guard.mts
@@ -10,26 +10,28 @@ type Options = readonly [];
 type MessageIds = 'useCanonicalGuard';
 
 /**
- * Length guards whose bound makes them exactly equivalent to `Arr.isEmpty` /
+ * Length guards whose bound makes them redundant with `Arr.isEmpty` /
  * `Arr.isNonEmpty`, keyed by guard name.
  *
- * Every entry is *type-identical*, not merely equivalent at runtime:
+ * `isEmpty` narrows to `FixedLengthArray<0, E> & Xs` and `isNonEmpty` to
+ * `MinLengthArray<1, E> & Xs`, so:
  *
- * - `FixedLengthTuple<0, E>` / `MaxLengthTuple<0, E>` /
- *   `BoundedLengthTuple<0, 0, E>` all resolve to `readonly []`, which is what
- *   `isEmpty` narrows to.
- * - `MinLengthArray<1, E>` is the definition of `NonEmptyArray<E>`, which is
- *   what `isNonEmpty` narrows to.
- *
- * The branded `isFixedLengthArray(xs, 0)` is deliberately absent: it narrows to
- * `FixedLengthArray<0, E>`, a strict subtype of `readonly []`, so rewriting it
- * to `isEmpty` would *widen* the narrowed type and can break call sites.
+ * - The `*Array` entries are **type-identical** — `isFixedLengthArray(xs, 0)`
+ *   and `isMinLengthArray(xs, 1)` produce exactly those types.
+ * - The `*Tuple` entries **narrow**: they resolve to the structural
+ *   `readonly []` / `readonly [E, ...E[]]`, and the canonical guards add the
+ *   brand on top. The result stays assignable everywhere the old type was, so
+ *   the rewrite is safe, but it is a strengthening rather than a pure rename.
  */
 const GUARD_REWRITES = [
+  { guard: 'isFixedLengthArray', bounds: [0], replacement: 'isEmpty' },
   { guard: 'isFixedLengthTuple', bounds: [0], replacement: 'isEmpty' },
   { guard: 'isMaxLengthTuple', bounds: [0], replacement: 'isEmpty' },
+  { guard: 'isMaxLengthArray', bounds: [0], replacement: 'isEmpty' },
   { guard: 'isBoundedLengthTuple', bounds: [0, 0], replacement: 'isEmpty' },
+  { guard: 'isBoundedLengthArray', bounds: [0, 0], replacement: 'isEmpty' },
   { guard: 'isMinLengthArray', bounds: [1], replacement: 'isNonEmpty' },
+  { guard: 'isMinLengthTuple', bounds: [1], replacement: 'isNonEmpty' },
 ] as const satisfies readonly Readonly<{
   guard: string;
   bounds: readonly number[];
@@ -50,7 +52,7 @@ export const preferCanonicalLengthGuard: TSESLint.RuleModule<
     schema: [],
     messages: {
       useCanonicalGuard:
-        'Replace `{{arrName}}.{{guard}}({{boundsText}})` with `{{arrName}}.{{replacement}}(...)`: it narrows to exactly the same type.',
+        'Replace `{{arrName}}.{{guard}}({{boundsText}})` with `{{arrName}}.{{replacement}}(...)`: the bound makes the two guards equivalent.',
     },
   },
 

--- a/packages/eslint-plugin-ts-data-forge/src/rules/prefer-canonical-length-guard.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/rules/prefer-canonical-length-guard.mts
@@ -4,10 +4,52 @@ import {
   type TSESTree,
 } from '@typescript-eslint/utils';
 import { getImportedLocalName, getTsDataForgeImport } from './import-utils.mjs';
+import { preferArrIsBoundedLengthArray } from './prefer-arr-is-bounded-length-array.mjs';
+import { preferArrIsFixedLengthArray } from './prefer-arr-is-fixed-length-array.mjs';
+import { preferArrIsMaxLengthArray } from './prefer-arr-is-max-length-array.mjs';
+import { preferArrIsMinLengthArray } from './prefer-arr-is-min-length-array.mjs';
+import { preferArrIsNonEmpty } from './prefer-arr-is-non-empty.mjs';
 
 type Options = readonly [];
 
-type MessageIds = 'useCanonicalGuard';
+type MessageIds =
+  | 'useCanonicalGuard'
+  | 'useIsBoundedLengthArray'
+  | 'useIsFixedLengthArray'
+  | 'useIsMaxLengthArray'
+  | 'useIsMinLengthArray'
+  | 'useIsNonEmpty';
+
+/**
+ * The `xs.length <op> n` → `Arr.is*` rules folded into this one.
+ *
+ * Their implementations are reused as-is rather than rewritten: this rule
+ * merges their visitors, so every case they already cover (type-aware array
+ * checks, `Arr` import insertion, the `&&`-bounded-range special case) keeps
+ * behaving exactly as before, and their co-located tests keep exercising them
+ * directly.
+ */
+const COMPARISON_RULES = [
+  preferArrIsNonEmpty,
+  preferArrIsMinLengthArray,
+  preferArrIsMaxLengthArray,
+  preferArrIsBoundedLengthArray,
+  preferArrIsFixedLengthArray,
+] as const;
+
+const MESSAGES = {
+  useCanonicalGuard:
+    'Replace `{{arrName}}.{{guard}}({{boundsText}})` with `{{arrName}}.{{replacement}}(...)`: the bound makes the two guards equivalent.',
+  useIsNonEmpty: preferArrIsNonEmpty.meta.messages.useIsNonEmpty,
+  useIsMinLengthArray:
+    preferArrIsMinLengthArray.meta.messages.useIsMinLengthArray,
+  useIsMaxLengthArray:
+    preferArrIsMaxLengthArray.meta.messages.useIsMaxLengthArray,
+  useIsBoundedLengthArray:
+    preferArrIsBoundedLengthArray.meta.messages.useIsBoundedLengthArray,
+  useIsFixedLengthArray:
+    preferArrIsFixedLengthArray.meta.messages.useIsFixedLengthArray,
+} as const satisfies Record<MessageIds, string>;
 
 /**
  * Length guards whose bound makes them redundant with `Arr.isEmpty` /
@@ -46,14 +88,11 @@ export const preferCanonicalLengthGuard: TSESLint.RuleModule<
     type: 'suggestion',
     docs: {
       description:
-        'Normalize degenerate `Arr` length guards (e.g. `Arr.isFixedLengthTuple(xs, 0)`) to `Arr.isEmpty` / `Arr.isNonEmpty`.',
+        'Normalize array-length checks to their canonical `Arr` guard: `xs.length <op> n` becomes the matching `Arr.is*` guard, and degenerate guards (e.g. `Arr.isFixedLengthTuple(xs, 0)`) become `Arr.isEmpty` / `Arr.isNonEmpty`.',
     },
     fixable: 'code',
     schema: [],
-    messages: {
-      useCanonicalGuard:
-        'Replace `{{arrName}}.{{guard}}({{boundsText}})` with `{{arrName}}.{{replacement}}(...)`: the bound makes the two guards equivalent.',
-    },
+    messages: MESSAGES,
   },
 
   create: (context) => {
@@ -64,48 +103,91 @@ export const preferCanonicalLengthGuard: TSESLint.RuleModule<
       'Arr',
     );
 
-    if (arrLocalName === undefined) return {};
+    const comparisonVisitors = COMPARISON_RULES.map((rule) =>
+      rule.create(context),
+    );
 
-    return {
-      CallExpression: (node) => {
-        const guardName = getGuardName(node, arrLocalName);
+    if (arrLocalName === undefined) return mergeVisitors(comparisonVisitors);
 
-        if (guardName === undefined) return;
+    return mergeVisitors([
+      ...comparisonVisitors,
+      {
+        CallExpression: (node) => {
+          const guardName = getGuardName(node, arrLocalName);
 
-        const rewrite = GUARD_REWRITES.find(
-          (entry) => entry.guard === guardName,
-        );
+          if (guardName === undefined) return;
 
-        if (rewrite === undefined || !matchesBounds(node, rewrite.bounds)) {
-          return;
-        }
+          const rewrite = GUARD_REWRITES.find(
+            (entry) => entry.guard === guardName,
+          );
 
-        const [array] = node.arguments;
+          if (rewrite === undefined || !matchesBounds(node, rewrite.bounds)) {
+            return;
+          }
 
-        if (array === undefined) return;
+          const [array] = node.arguments;
 
-        const arrayText = sourceCode.getText(array);
+          if (array === undefined) return;
 
-        context.report({
-          node,
-          messageId: 'useCanonicalGuard',
-          data: {
-            arrName: arrLocalName,
-            guard: guardName,
-            boundsText: ['…', ...rewrite.bounds.map(String)].join(', '),
-            replacement: rewrite.replacement,
-          },
-          fix: (fixer) =>
-            fixer.replaceText(
-              node,
-              `${arrLocalName}.${rewrite.replacement}(${arrayText})`,
-            ),
-        });
+          const arrayText = sourceCode.getText(array);
+
+          context.report({
+            node,
+            messageId: 'useCanonicalGuard',
+            data: {
+              arrName: arrLocalName,
+              guard: guardName,
+              boundsText: ['…', ...rewrite.bounds.map(String)].join(', '),
+              replacement: rewrite.replacement,
+            },
+            fix: (fixer) =>
+              fixer.replaceText(
+                node,
+                `${arrLocalName}.${rewrite.replacement}(${arrayText})`,
+              ),
+          });
+        },
       },
-    };
+    ]);
   },
   defaultOptions: [],
 } as const;
+
+/**
+ * Combines several rule listeners into one, calling every handler registered
+ * for a given selector in order.
+ */
+const mergeVisitors = (
+  // `RuleListener` holds mutable AST handler signatures, so it is not deeply
+  // readonly.
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  visitors: readonly TSESLint.RuleListener[],
+): TSESLint.RuleListener => {
+  const mut_merged: Record<string, ((node: never) => void)[]> = {};
+
+  for (const visitor of visitors) {
+    for (const [selector, handler] of Object.entries(visitor)) {
+      if (typeof handler !== 'function') continue;
+
+      const mut_handlers = mut_merged[selector] ?? [];
+
+      mut_handlers.push(handler);
+
+      mut_merged[selector] = mut_handlers;
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(mut_merged).map(([selector, handlers]) => [
+      selector,
+      (node: never) => {
+        for (const handler of handlers) {
+          handler(node);
+        }
+      },
+    ]),
+  );
+};
 
 /** The `Arr.<guard>` method name of `node`, or `undefined` for other calls. */
 const getGuardName = (

--- a/packages/eslint-plugin-ts-data-forge/src/rules/prefer-canonical-length-guard.test.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/rules/prefer-canonical-length-guard.test.mts
@@ -13,6 +13,77 @@ const tester = new RuleTester({
   },
 });
 
+// The folded-in comparison rules are type-aware, so they need a TypeScript
+// program; the guard-normalization half does not.
+const typedTester = new RuleTester({
+  languageOptions: {
+    parser,
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      projectService: {
+        allowDefaultProject: ['*.ts*'],
+      },
+      tsconfigRootDir: `${import.meta.dirname}/../..`,
+    },
+  },
+});
+
+describe('prefer-canonical-length-guard (folded-in length comparisons)', () => {
+  typedTester.run('prefer-canonical-length-guard', preferCanonicalLengthGuard, {
+    valid: [
+      {
+        name: 'ignores non-array length comparisons',
+        code: dedent`
+          const str = 'hello';
+          const ok = str.length > 0;
+        `,
+      },
+    ],
+    invalid: [
+      {
+        name: 'xs.length > 0 becomes Arr.isNonEmpty(xs)',
+        code: dedent`
+          const xs = [1, 2, 3];
+          const ok = xs.length > 0;
+        `,
+        output: dedent`
+          import { Arr } from 'ts-data-forge';
+          const xs = [1, 2, 3];
+          const ok = Arr.isNonEmpty(xs);
+        `,
+        errors: [{ messageId: 'useIsNonEmpty' }],
+      },
+      {
+        name: 'xs.length >= 2 becomes Arr.isMinLengthArray(xs, 2)',
+        code: dedent`
+          const xs = [1, 2, 3];
+          const ok = xs.length >= 2;
+        `,
+        output: dedent`
+          import { Arr } from 'ts-data-forge';
+          const xs = [1, 2, 3];
+          const ok = Arr.isMinLengthArray(xs, 2);
+        `,
+        errors: [{ messageId: 'useIsMinLengthArray' }],
+      },
+      {
+        name: 'xs.length === 3 becomes Arr.isFixedLengthArray(xs, 3)',
+        code: dedent`
+          const xs = [1, 2, 3];
+          const ok = xs.length === 3;
+        `,
+        output: dedent`
+          import { Arr } from 'ts-data-forge';
+          const xs = [1, 2, 3];
+          const ok = Arr.isFixedLengthArray(xs, 3);
+        `,
+        errors: [{ messageId: 'useIsFixedLengthArray' }],
+      },
+    ],
+  });
+});
+
 describe('prefer-canonical-length-guard', () => {
   tester.run('prefer-canonical-length-guard', preferCanonicalLengthGuard, {
     valid: [

--- a/packages/eslint-plugin-ts-data-forge/src/rules/prefer-canonical-length-guard.test.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/rules/prefer-canonical-length-guard.test.mts
@@ -1,0 +1,213 @@
+import parser from '@typescript-eslint/parser';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+import { preferCanonicalLengthGuard } from './prefer-canonical-length-guard.mjs';
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser,
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+    },
+  },
+});
+
+describe('prefer-canonical-length-guard', () => {
+  tester.run('prefer-canonical-length-guard', preferCanonicalLengthGuard, {
+    valid: [
+      {
+        name: 'ignores non-degenerate bounds',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isFixedLengthTuple(xs, 2);
+        `,
+      },
+      {
+        name: 'ignores isMinLengthArray with a bound other than 1',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isMinLengthArray(xs, 2);
+        `,
+      },
+      {
+        name: 'ignores isBoundedLengthTuple unless both bounds are 0',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isBoundedLengthTuple(xs, 0, 1);
+        `,
+      },
+      {
+        name: 'ignores the branded isFixedLengthArray (it narrows more tightly)',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isFixedLengthArray(xs, 0);
+        `,
+      },
+      {
+        name: 'ignores a non-literal bound',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const n = 0;
+          const ok = Arr.isFixedLengthTuple(xs, n);
+        `,
+      },
+      {
+        name: 'ignores an Arr that is not from ts-data-forge',
+        code: dedent`
+          import { Arr } from './my-helpers.mjs';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isFixedLengthTuple(xs, 0);
+        `,
+      },
+      {
+        name: 'ignores already-canonical guards',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isEmpty(xs);
+        `,
+      },
+      {
+        name: 'ignores spread arguments',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const args: readonly [readonly number[], 0];
+          const ok = Arr.isFixedLengthTuple(...args);
+        `,
+      },
+    ],
+    invalid: [
+      {
+        name: 'isFixedLengthTuple(xs, 0) becomes isEmpty(xs)',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isFixedLengthTuple(xs, 0);
+        `,
+        output: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isEmpty(xs);
+        `,
+        errors: [{ messageId: 'useCanonicalGuard' }],
+      },
+      {
+        name: 'isMaxLengthTuple(xs, 0) becomes isEmpty(xs)',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isMaxLengthTuple(xs, 0);
+        `,
+        output: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isEmpty(xs);
+        `,
+        errors: [{ messageId: 'useCanonicalGuard' }],
+      },
+      {
+        name: 'isBoundedLengthTuple(xs, 0, 0) becomes isEmpty(xs)',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isBoundedLengthTuple(xs, 0, 0);
+        `,
+        output: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isEmpty(xs);
+        `,
+        errors: [{ messageId: 'useCanonicalGuard' }],
+      },
+      {
+        name: 'isMinLengthArray(xs, 1) becomes isNonEmpty(xs)',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isMinLengthArray(xs, 1);
+        `,
+        output: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isNonEmpty(xs);
+        `,
+        errors: [{ messageId: 'useCanonicalGuard' }],
+      },
+      {
+        name: 'keeps a complex array expression intact',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const obj: Readonly<{ items: readonly number[] }>;
+          const ok = Arr.isFixedLengthTuple(obj.items.filter((x) => x > 0), 0);
+        `,
+        output: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const obj: Readonly<{ items: readonly number[] }>;
+          const ok = Arr.isEmpty(obj.items.filter((x) => x > 0));
+        `,
+        errors: [{ messageId: 'useCanonicalGuard' }],
+      },
+      {
+        name: 'resolves an aliased Arr import',
+        code: dedent`
+          import { Arr as A } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = A.isFixedLengthTuple(xs, 0);
+        `,
+        output: dedent`
+          import { Arr as A } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = A.isEmpty(xs);
+        `,
+        errors: [{ messageId: 'useCanonicalGuard' }],
+      },
+      {
+        name: 'rewrites several guards in one file',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const a = Arr.isFixedLengthTuple(xs, 0);
+          const b = Arr.isMinLengthArray(xs, 1);
+        `,
+        output: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const a = Arr.isEmpty(xs);
+          const b = Arr.isNonEmpty(xs);
+        `,
+        errors: [
+          { messageId: 'useCanonicalGuard' },
+          { messageId: 'useCanonicalGuard' },
+        ],
+      },
+    ],
+  });
+});

--- a/packages/eslint-plugin-ts-data-forge/src/rules/prefer-canonical-length-guard.test.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/rules/prefer-canonical-length-guard.test.mts
@@ -44,15 +44,6 @@ describe('prefer-canonical-length-guard', () => {
         `,
       },
       {
-        name: 'ignores the branded isFixedLengthArray (it narrows more tightly)',
-        code: dedent`
-          import { Arr } from 'ts-data-forge';
-
-          declare const xs: readonly number[];
-          const ok = Arr.isFixedLengthArray(xs, 0);
-        `,
-      },
-      {
         name: 'ignores a non-literal bound',
         code: dedent`
           import { Arr } from 'ts-data-forge';
@@ -91,6 +82,38 @@ describe('prefer-canonical-length-guard', () => {
       },
     ],
     invalid: [
+      {
+        name: 'isFixedLengthArray(xs, 0) becomes isEmpty(xs)',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isFixedLengthArray(xs, 0);
+        `,
+        output: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isEmpty(xs);
+        `,
+        errors: [{ messageId: 'useCanonicalGuard' }],
+      },
+      {
+        name: 'isMinLengthTuple(xs, 1) becomes isNonEmpty(xs)',
+        code: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isMinLengthTuple(xs, 1);
+        `,
+        output: dedent`
+          import { Arr } from 'ts-data-forge';
+
+          declare const xs: readonly number[];
+          const ok = Arr.isNonEmpty(xs);
+        `,
+        errors: [{ messageId: 'useCanonicalGuard' }],
+      },
       {
         name: 'isFixedLengthTuple(xs, 0) becomes isEmpty(xs)',
         code: dedent`

--- a/packages/eslint-plugin-ts-data-forge/src/rules/rules.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/rules/rules.mts
@@ -9,6 +9,7 @@ import { preferArrIsNonEmpty } from './prefer-arr-is-non-empty.mjs';
 import { preferArrSum } from './prefer-arr-sum.mjs';
 import { preferAsInt } from './prefer-as-int.mjs';
 import { preferCanonicalArraySlicing } from './prefer-canonical-array-slicing.mjs';
+import { preferCanonicalLengthGuard } from './prefer-canonical-length-guard.mjs';
 import { preferComparisonOverNullishGuard } from './prefer-comparison-over-nullish-guard.mjs';
 import { preferIsNonNullObject } from './prefer-is-non-null-object.mjs';
 import { preferIsRecordAndHasKey } from './prefer-is-record-and-has-key.mjs';
@@ -18,6 +19,7 @@ import { preferRangeForLoop } from './prefer-range-for-loop.mjs';
 
 export const tsDataForgeRules = {
   'prefer-canonical-array-slicing': preferCanonicalArraySlicing,
+  'prefer-canonical-length-guard': preferCanonicalLengthGuard,
   'prefer-arr-is-min-length-array': preferArrIsMinLengthArray,
   'prefer-arr-is-max-length-array': preferArrIsMaxLengthArray,
   'prefer-arr-is-bounded-length-array': preferArrIsBoundedLengthArray,

--- a/packages/eslint-plugin-ts-data-forge/src/rules/rules.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/rules/rules.mts
@@ -1,11 +1,6 @@
 import { type ESLintPlugin } from '../types.mjs';
 import { noUnnecessaryTypeGuard } from './no-unnecessary-type-guard.mjs';
 import { preferArrIsArray } from './prefer-arr-is-array.mjs';
-import { preferArrIsBoundedLengthArray } from './prefer-arr-is-bounded-length-array.mjs';
-import { preferArrIsFixedLengthArray } from './prefer-arr-is-fixed-length-array.mjs';
-import { preferArrIsMaxLengthArray } from './prefer-arr-is-max-length-array.mjs';
-import { preferArrIsMinLengthArray } from './prefer-arr-is-min-length-array.mjs';
-import { preferArrIsNonEmpty } from './prefer-arr-is-non-empty.mjs';
 import { preferArrSum } from './prefer-arr-sum.mjs';
 import { preferAsInt } from './prefer-as-int.mjs';
 import { preferCanonicalArraySlicing } from './prefer-canonical-array-slicing.mjs';
@@ -20,12 +15,7 @@ import { preferRangeForLoop } from './prefer-range-for-loop.mjs';
 export const tsDataForgeRules = {
   'prefer-canonical-array-slicing': preferCanonicalArraySlicing,
   'prefer-canonical-length-guard': preferCanonicalLengthGuard,
-  'prefer-arr-is-min-length-array': preferArrIsMinLengthArray,
-  'prefer-arr-is-max-length-array': preferArrIsMaxLengthArray,
-  'prefer-arr-is-bounded-length-array': preferArrIsBoundedLengthArray,
-  'prefer-arr-is-fixed-length-array': preferArrIsFixedLengthArray,
   'prefer-arr-is-array': preferArrIsArray,
-  'prefer-arr-is-non-empty': preferArrIsNonEmpty,
   'prefer-arr-sum': preferArrSum,
   'prefer-as-int': preferAsInt,
   'prefer-is-non-null-object': preferIsNonNullObject,

--- a/packages/ts-data-forge/samples/src/array/is-empty-example.mts
+++ b/packages/ts-data-forge/samples/src/array/is-empty-example.mts
@@ -13,7 +13,9 @@ if (import.meta.vitest !== undefined) {
     assert.isFalse(Arr.isEmpty(words));
 
     if (Arr.isEmpty(emptyNumbers)) {
-      assert.deepStrictEqual(emptyNumbers, []);
+      // `isEmpty` narrows to the branded `FixedLengthArray<0, number>`, so the
+      // expected value is annotated with the unbranded type.
+      assert.deepStrictEqual<readonly number[]>(emptyNumbers, []);
     }
 
     // embed-sample-code-ignore-below

--- a/packages/ts-data-forge/src/array/impl/array-utils-validation.mts
+++ b/packages/ts-data-forge/src/array/impl/array-utils-validation.mts
@@ -1,10 +1,11 @@
 import {
   type BoolOr,
   type BoundedLengthTuple,
+  type FixedLengthArray,
   type FixedLengthTuple,
   type MaxLengthTuple,
+  type MinLengthArray,
   type MinLengthTuple,
-  type NonEmptyArray,
   type TypeEq,
 } from 'ts-type-forge';
 import { asUint32, Num } from '../../number/index.mjs';
@@ -60,12 +61,15 @@ type Cast<A, B> = A extends B ? A : never;
  * assert.isFalse(Arr.isEmpty(words));
  *
  * if (Arr.isEmpty(emptyNumbers)) {
- *   assert.deepStrictEqual(emptyNumbers, []);
+ *   // `isEmpty` narrows to the branded `FixedLengthArray<0, number>`, so the
+ *   // expected value is annotated with the unbranded type.
+ *   assert.deepStrictEqual<readonly number[]>(emptyNumbers, []);
  * }
  * ```
  */
-export const isEmpty = <E,>(array: readonly E[]): array is readonly [] =>
-  array.length === 0;
+export const isEmpty = <Xs extends readonly unknown[]>(
+  array: Xs,
+): array is FixedLengthArray<0, Xs[number]> & Xs => array.length === 0;
 
 /**
  * Type guard that checks if an array is non-empty.
@@ -86,9 +90,9 @@ export const isEmpty = <E,>(array: readonly E[]): array is readonly [] =>
  * }
  * ```
  */
-export const isNonEmpty = <E,>(
-  array: readonly E[],
-): array is NonEmptyArray<E> => array.length > 0;
+export const isNonEmpty = <Xs extends readonly unknown[]>(
+  array: Xs,
+): array is MinLengthArray<1, Xs[number]> & Xs => array.length > 0;
 
 /**
  * Checks if an array has a specific length.


### PR DESCRIPTION
## 1. `Arr.isEmpty` / `Arr.isNonEmpty` now narrow to branded types

`Arr.isEmpty` narrowed to the bare structural `readonly []` — the brand was simply missing, so it was **not** equivalent to `Arr.isFixedLengthArray(xs, 0)`. `Arr.isNonEmpty` did carry the brand but returned `NonEmptyArray` instead of intersecting with the input type the way `Arr.isMinLengthArray` does, so it dropped tuple types.

| guard | before | after |
| :---- | :----- | :---- |
| `Arr.isEmpty(xs)` | `readonly []` | `FixedLengthArray<0, E> & Xs` |
| `Arr.isNonEmpty(xs)` | `NonEmptyArray<E>` | `MinLengthArray<1, E> & Xs` |

Both now behave exactly like their `is*LengthArray` counterparts.

**BREAKING CHANGE**: the narrowed types are strictly narrower than before. Reads of the narrowed value keep compiling, but an explicit annotation such as `const empty: readonly [] = xs` after the guard, or passing the narrowed value where an unbranded array literal is expected, may now need the unbranded type spelled out. The only place this surfaced in-repo was one sample assertion.

## 2. New rule: `prefer-canonical-length-guard`

Normalizes degenerate `Arr` length guards to `Arr.isEmpty` / `Arr.isNonEmpty`. The table follows the corrected semantics above:

| from | to | relation |
| :--- | :-- | :------- |
| `Arr.isFixedLengthArray(xs, 0)` | `Arr.isEmpty(xs)` | type-identical |
| `Arr.isMinLengthArray(xs, 1)` | `Arr.isNonEmpty(xs)` | type-identical |
| `Arr.isFixedLengthTuple(xs, 0)` | `Arr.isEmpty(xs)` | strengthens (adds brand) |
| `Arr.isMaxLengthTuple(xs, 0)` | `Arr.isEmpty(xs)` | strengthens |
| `Arr.isMaxLengthArray(xs, 0)` | `Arr.isEmpty(xs)` | strengthens |
| `Arr.isBoundedLengthTuple(xs, 0, 0)` | `Arr.isEmpty(xs)` | strengthens |
| `Arr.isBoundedLengthArray(xs, 0, 0)` | `Arr.isEmpty(xs)` | strengthens |
| `Arr.isMinLengthTuple(xs, 1)` | `Arr.isNonEmpty(xs)` | strengthens |

The `*Tuple` guards resolve to structural `readonly []` / `readonly [E, ...E[]]`; the canonical guards add the brand on top. The result stays assignable everywhere the old type was, so the rewrite is safe — it is a strengthening rather than a pure rename.

Implementation notes: the `Arr` binding is resolved through the actual `ts-data-forge` import (aliases handled, unrelated local `Arr` ignored), only literal bounds match, and calls with spread arguments or explicit type arguments are skipped.

## 3. `prefer-canonical-length-guard` absorbs the five comparison rules

`prefer-arr-is-non-empty`, `prefer-arr-is-min-length-array`, `prefer-arr-is-max-length-array`, `prefer-arr-is-bounded-length-array` and `prefer-arr-is-fixed-length-array` are removed from the rule registry and folded into `prefer-canonical-length-guard`, so one rule now covers both directions of normalization: `xs.length <op> n` → `Arr.is*` guard, and degenerate guard → canonical guard.

The five implementations are reused **as-is** — the merged rule composes their visitors rather than reimplementing them — so every case they covered (type-aware array checks, `Arr` import insertion, the `&&`-bounded-range special case) behaves exactly as before, their message IDs are preserved, and their co-located tests keep exercising them directly.

**BREAKING CHANGE**: those five rule names no longer exist. Replace them with the single `ts-data-forge/prefer-canonical-length-guard` in your flat config. 12 rules remain in the registry.

## Verification

`ws:build`, `ws:test` (ts-data-forge 3150 tests, plugin 248 tests), `ws:lint` (0 errors), `cspell`, `md`, `ws:doc:embed:jsdoc`, `fmt:full` — all pass. CI is green (19/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc6fWvHXu4dKzmED1HujD4