### PR TITLE
feat(eslint-plugin): export a recommended config preset

### DIFF
--- a/.changeset/eslint-plugin-config-preset.md
+++ b/.changeset/eslint-plugin-config-preset.md
@@ -1,0 +1,17 @@
+---
+'eslint-plugin-ts-data-forge': minor
+---
+
+Ship a `recommended` config preset. `eslintPluginTsDataForge.configs.recommended`
+is a flat-config object that registers the plugin and enables every rule at
+`error`, so consuming projects can start from:
+
+```ts
+export default [eslintPluginTsDataForge.configs.recommended];
+```
+
+The preset registers the exported plugin object itself, so listing the plugin in
+your own `plugins` record alongside the preset does not trigger ESLint's
+`Cannot redefine plugin` error.
+
+Also exports the `ESLintFlatConfig` type alongside the existing `ESLintPlugin`.

--- a/packages/eslint-plugin-ts-data-forge/README.md
+++ b/packages/eslint-plugin-ts-data-forge/README.md
@@ -12,6 +12,38 @@ Requires ESLint 9+ (flat config) and TypeScript. Some rules are type-aware and n
 
 ## Usage (flat config)
 
+The plugin ships a `recommended` config preset that registers the plugin and
+turns on **every** rule at `error`:
+
+```ts
+// eslint.config.mts
+import { eslintPluginTsDataForge } from 'eslint-plugin-ts-data-forge';
+
+export default [eslintPluginTsDataForge.configs.recommended];
+```
+
+Since the preset is a plain flat-config object, individual rules can be
+adjusted by a later config entry:
+
+```ts
+// eslint.config.mts
+import {
+    eslintPluginTsDataForge,
+    type EslintTsDataForgeRules,
+} from 'eslint-plugin-ts-data-forge';
+
+export default [
+    eslintPluginTsDataForge.configs.recommended,
+    {
+        rules: {
+            'ts-data-forge/prefer-range-for-loop': 'off',
+        } satisfies Partial<EslintTsDataForgeRules>,
+    },
+];
+```
+
+Or register the plugin yourself and pick the rules one by one:
+
 ```ts
 // eslint.config.mts
 import {

--- a/packages/eslint-plugin-ts-data-forge/src/index.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/index.mts
@@ -4,4 +4,4 @@ export type {
   EslintTsDataForgeRulesOption,
 } from './rule-types.mjs';
 export { tsDataForgeRules } from './rules/index.mjs';
-export { type ESLintPlugin } from './types.mjs';
+export { type ESLintFlatConfig, type ESLintPlugin } from './types.mjs';

--- a/packages/eslint-plugin-ts-data-forge/src/plugin.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/plugin.mts
@@ -1,9 +1,52 @@
 import { tsDataForgeRules } from './rules/index.mjs';
-import { type ESLintPlugin } from './types.mjs';
+import { type ESLintFlatConfig, type ESLintPlugin } from './types.mjs';
 
-export const eslintPluginTsDataForge: ESLintPlugin = {
+/**
+ * Every rule this plugin ships, at `error`.
+ *
+ * The `satisfies` clause below is keyed off {@link tsDataForgeRules}, so adding
+ * a rule without listing it here fails to type-check.
+ */
+const recommendedRules = {
+  'ts-data-forge/prefer-canonical-array-slicing': 'error',
+  'ts-data-forge/prefer-canonical-length-guard': 'error',
+  'ts-data-forge/prefer-arr-is-array': 'error',
+  'ts-data-forge/prefer-arr-sum': 'error',
+  'ts-data-forge/prefer-as-int': 'error',
+  'ts-data-forge/prefer-is-non-null-object': 'error',
+  'ts-data-forge/prefer-range-for-loop': 'error',
+  'ts-data-forge/prefer-is-record-and-has-key': 'error',
+  'ts-data-forge/prefer-num-safe-parse-int': 'error',
+  'ts-data-forge/prefer-num-safe-parse-float': 'error',
+  'ts-data-forge/no-unnecessary-type-guard': 'error',
+  'ts-data-forge/prefer-comparison-over-nullish-guard': 'error',
+} as const satisfies Readonly<
+  Record<`ts-data-forge/${keyof typeof tsDataForgeRules}`, 'error'>
+>;
+
+const recommendedConfig = {
+  name: 'ts-data-forge/recommended',
+  plugins: {
+    // Resolved lazily so that this config registers the *same* object that
+    // `eslintPluginTsDataForge` refers to. ESLint rejects a plugin name that
+    // maps to two different objects with `Cannot redefine plugin`, which is
+    // what a user combining this preset with their own
+    // `plugins: { 'ts-data-forge': eslintPluginTsDataForge }` entry would hit
+    // if the preset embedded a separate copy of the plugin.
+    get 'ts-data-forge'(): ESLintPlugin {
+      return eslintPluginTsDataForge;
+    },
+  },
+  rules: recommendedRules,
+} as const satisfies ESLintFlatConfig;
+
+export const eslintPluginTsDataForge = {
   meta: {
     name: 'eslint-plugin-ts-data-forge',
   },
   rules: tsDataForgeRules,
-} as const;
+  configs: {
+    /** Enables every rule of this plugin at `error`. */
+    recommended: recommendedConfig,
+  },
+} as const satisfies ESLintPlugin;

--- a/packages/eslint-plugin-ts-data-forge/src/plugin.test.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/plugin.test.mts
@@ -1,0 +1,24 @@
+import { eslintPluginTsDataForge } from './plugin.mjs';
+import { tsDataForgeRules } from './rules/index.mjs';
+
+describe('eslintPluginTsDataForge.configs.recommended', () => {
+  const recommended = eslintPluginTsDataForge.configs.recommended;
+
+  test('enables every rule of the plugin, and nothing else, at "error"', () => {
+    assert.deepStrictEqual(
+      recommended.rules,
+      Object.fromEntries(
+        Object.keys(tsDataForgeRules).map((name) => [
+          `ts-data-forge/${name}`,
+          'error',
+        ]),
+      ),
+    );
+  });
+
+  test('registers the exported plugin object itself', () => {
+    // Registering a *copy* would make `Cannot redefine plugin` errors possible
+    // for users who also list the plugin in their own `plugins` record.
+    expect(recommended.plugins['ts-data-forge']).toBe(eslintPluginTsDataForge);
+  });
+});

--- a/packages/eslint-plugin-ts-data-forge/src/types.mts
+++ b/packages/eslint-plugin-ts-data-forge/src/types.mts
@@ -2,3 +2,5 @@ import { type TSESLint } from '@typescript-eslint/utils';
 import { type DeepReadonly } from 'ts-type-forge';
 
 export type ESLintPlugin = DeepReadonly<TSESLint.FlatConfig.Plugin>;
+
+export type ESLintFlatConfig = DeepReadonly<TSESLint.FlatConfig.Config>;


### PR DESCRIPTION
## Summary

`eslint-plugin-ts-data-forge` now ships a config preset, so consumers no longer
have to register the plugin and list every rule by hand:

```ts
// eslint.config.mts
import { eslintPluginTsDataForge } from 'eslint-plugin-ts-data-forge';

export default [eslintPluginTsDataForge.configs.recommended];
```

`recommended` enables **all 12 rules at `error`**. Only one preset is provided —
with every rule at `error`, a separate `all` would be byte-identical and would
only raise the question of which one to use. Individual rules can still be
adjusted by a later config entry, since the preset is a plain flat-config
object.

## Design notes

**The preset registers the exported plugin object itself.**
ESLint throws `Cannot redefine plugin "ts-data-forge"` when one plugin name maps
to two *different* objects, so embedding a copy of the plugin in the preset
would break for anyone who combines it with an existing hand-written
`plugins: { 'ts-data-forge': eslintPluginTsDataForge }` entry. The preset's
`plugins` entry is therefore a lazy getter returning the exported object — no
mutation, identity preserved.

**A forgotten rule fails to type-check.**
The rule record is constrained by
``satisfies Readonly<Record<`ts-data-forge/${keyof typeof tsDataForgeRules}`, 'error'>>``,
so adding a rule to `tsDataForgeRules` without listing it in the preset is a
compile error.

The generated `EslintTsDataForgeRules` was deliberately *not* used for that
constraint: it excludes the bare `'error'` string for optioned rules
(`'off' | Linter.Severity | [StringSeverity, Options]`), which would force the
preset to copy each rule's own default options — a drift hazard for
`no-unnecessary-type-guard`.

## Changes

- `src/plugin.mts` — the preset
- `src/plugin.test.mts` — asserts the preset covers exactly the plugin's rules,
  all at `error`, and registers the plugin object itself (new)
- `src/types.mts` / `src/index.mts` — add and re-export the `ESLintFlatConfig` type
- `README.md` — document preset / preset-with-overrides / manual registration
- `.changeset/` — minor

## Test plan

- `pnpm run ws:build`, `ws:test`, `ws:lint:fix`, `fmt` all pass; no generated-file drift
- Verified against a real ESLint `Linter`, for both `src` and the built `dist`:
  the preset alone and the preset combined with a hand-written plugin
  registration both resolve, and a preset rule fires at severity 2
- Confirmed the drift guard by removing a rule from the preset (TS2741) and the
  identity requirement by registering a shallow copy of the plugin
  (`Cannot redefine plugin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSHerEEif4V1mdtUJBqVue

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSHerEEif4V1mdtUJBqVue)_