### PR TITLE
chore: extend cspell scope to .changeset/.github and disable required code-owner review

### DIFF
--- a/.cspell.config.yaml
+++ b/.cspell.config.yaml
@@ -4,6 +4,7 @@ allowCompoundWords: true
 caseSensitive: false
 ignoreRandomStrings: true
 words:
+  - amannn
   - anthropics
   - bivariant
   - contravariance
@@ -26,6 +27,7 @@ words:
   - unshifted
   - unstringifiable
   - uppercased
+  - vitest
   - xnor
 ignorePaths:
   - pnpm-lock.yaml

--- a/github/rulesets/main.json
+++ b/github/rulesets/main.json
@@ -37,7 +37,7 @@
         "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": true,
         "required_reviewers": [],
-        "require_code_owner_review": true,
+        "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
         "allowed_merge_methods": ["squash"]

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "codemod:full:readonly": "convert-to-readonly 'packages/*/{src,scripts,samples,test}/**/*.{mts,tsx}'",
     "codemod:uncommitted:as-const": "append-as-const --uncommitted 'packages/*/{src,scripts,samples,test}/**/*.{mts,tsx}'",
     "codemod:uncommitted:readonly": "convert-to-readonly --uncommitted 'packages/*/{src,scripts,samples,test}/**/*.{mts,tsx}'",
-    "cspell": "cspell \"**\" --gitignore --gitignore-root ./ --no-progress",
+    "cspell": "cspell \"{**,.changeset/**/*,.github/**/*}\" --gitignore --gitignore-root ./ --no-progress",
     "fmt": "format-uncommitted",
     "fmt:diff": "format-diff-from origin/main",
     "fmt:full": "prettier --ignore-unknown --no-error-on-unmatched-pattern --write .",


### PR DESCRIPTION
## Changes

- **cspell**: extend the scan glob to include `.changeset/**/*` and `.github/**/*` (previously excluded), so changeset files and workflow files are spell-checked going forward. Motivation: `.changeset` files were being skipped even for repos that may adopt changesets later.
- **cspell dictionary**: add `amannn`, `vitest` — words newly surfaced by the wider scan (`amannn/action-semantic-pull-request` action ref, Vitest references in workflows).
- **ruleset**: set `require_code_owner_review` to `false` in `github/rulesets/main.json`. The code-owner-review requirement was blocking Dependabot auto-merge. Only the active ruleset file is changed; `bk/` is a regenerated backup snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)