### PR TITLE
fix(array): let map, toFilled and toRangeFilled report a tuple shape under a generic parameter

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,28 @@
+---
+'ts-data-forge': patch
+---
+
+`Arr.map`, `Arr.toFilled` and `Arr.toRangeFilled` again report the plain
+homomorphic mapping (`{ [K in keyof Ar]: B }`) for an array or tuple that
+carries no length brand, so transforming a tuple into a same-length tuple
+works inside a function that is itself generic over the tuple:
+
+```ts
+const mapValues = <const T extends readonly Readonly<{ v: unknown }>[]>(
+    boxes: T,
+): Readonly<{ [K in keyof T]: unknown }> => Arr.map(boxes, (b) => b.v);
+```
+
+Since v14 the return type was a conditional branching on
+`HasLengthConstraint<Ar>`, which a _generic_ `Ar` cannot decide. The
+conditional stayed deferred and its branded branch made the result
+unassignable to the caller's own mapping, so callers had to reach for a type
+assertion. Concrete tuples were unaffected and keep the same result as before.
+
+Brand-carrying arrays are unaffected too: they select a separate overload that
+still returns `ChangeArrayElement<Ar, …>`, so `Arr.map` on a
+`MinLengthArray<2, number>` still yields a `MinLengthArray<2, …>`.
+
+`Arr.toSorted`, `Arr.toSortedBy`, `Arr.toReversed`, `Arr.toUpdated`,
+`Arr.tail`, `Arr.butLast` and `Arr.zip` still do not resolve under a generic
+array parameter and are unchanged here.

--- a/packages/ts-data-forge/src/array/impl/array-utils-modification.mts
+++ b/packages/ts-data-forge/src/array/impl/array-utils-modification.mts
@@ -2,11 +2,10 @@ import {
   type ChangeArrayElement,
   type ConstrainedList,
   type FixedLengthTuple,
-  type HasLengthConstraint,
   type Increment,
   type IsFixedLengthList,
   type NonEmptyArray,
-  type NonEmptyTuple,
+  type UnknownBrand,
 } from 'ts-type-forge';
 import { asPositiveUint32 } from '../../number/index.mjs';
 import { castMutable } from '../../others/index.mjs';
@@ -356,29 +355,33 @@ const toUnshiftedImpl = <Ar extends readonly unknown[], const V>(
  * assert.deepStrictEqual(filledCurried, ['x', 'x', 'x']);
  * ```
  */
+export function toFilled<
+  const Ar extends readonly unknown[] & UnknownBrand,
+  const V,
+>(array: Ar, value: V): ChangeArrayElement<Ar, V>;
+
+// For an array or tuple that carries no length brand the homomorphic mapping
+// already covers every case the conditional spelled out — a fixed-length tuple
+// keeps its length, `readonly [A, ...A[]]` stays non-empty, and `readonly A[]`
+// stays unbounded. Stating it directly is what keeps this usable from a
+// caller that is itself generic over the array: a conditional a *generic* `Ar`
+// cannot decide stays deferred, and its branded branch is then not assignable
+// to the caller's own mapping.
 export function toFilled<const Ar extends readonly unknown[], const V>(
   array: Ar,
   value: V,
-): HasLengthConstraint<Ar> extends true
-  ? ChangeArrayElement<Ar, V>
-  : IsFixedLengthList<Ar> extends true
-    ? FixedLengthTuple<Ar['length'], V>
-    : Ar extends NonEmptyTuple<unknown>
-      ? NonEmptyArray<V>
-      : readonly V[];
+): Readonly<{ [K in keyof Ar]: V }>;
 
-// curried version
+// curried version — the two cases have to be overloads of the *returned*
+// function, spelled as an intersection of function types (see `Arr.map`).
 export function toFilled<const V>(
   value: V,
-): <const Ar extends readonly unknown[]>(
+): (<const Ar extends readonly unknown[] & UnknownBrand>(
   array: Ar,
-) => HasLengthConstraint<Ar> extends true
-  ? ChangeArrayElement<Ar, V>
-  : IsFixedLengthList<Ar> extends true
-    ? FixedLengthTuple<Ar['length'], V>
-    : Ar extends NonEmptyTuple<unknown>
-      ? NonEmptyArray<V>
-      : readonly V[];
+) => ChangeArrayElement<Ar, V>) &
+  (<const Ar extends readonly unknown[]>(
+    array: Ar,
+  ) => Readonly<{ [K in keyof Ar]: V }>);
 
 export function toFilled<E>(
   ...args: readonly [array: readonly E[], value: E] | readonly [value: E]
@@ -412,6 +415,20 @@ const toFilledImpl = <E,>(array: readonly E[], value: E): readonly E[] =>
  * assert.deepStrictEqual(filledPrefix, [8, 8, 2, 3, 4]);
  * ```
  */
+export function toRangeFilled<
+  const Ar extends readonly unknown[] & UnknownBrand,
+  const V,
+>(
+  array: Ar,
+  value: V,
+  fillRange: readonly [
+    start: ArgArrayIndexWithNegative<Ar>,
+    end: ArgArrayIndexWithNegative<Ar>,
+  ],
+): ChangeArrayElement<Ar, V | Ar[number]>;
+
+// See `toFilled` for why the unbranded case states the homomorphic mapping
+// directly instead of going through a conditional.
 export function toRangeFilled<const Ar extends readonly unknown[], const V>(
   array: Ar,
   value: V,
@@ -419,13 +436,7 @@ export function toRangeFilled<const Ar extends readonly unknown[], const V>(
     start: ArgArrayIndexWithNegative<Ar>,
     end: ArgArrayIndexWithNegative<Ar>,
   ],
-): HasLengthConstraint<Ar> extends true
-  ? ChangeArrayElement<Ar, V | Ar[number]>
-  : IsFixedLengthList<Ar> extends true
-    ? FixedLengthTuple<Ar['length'], V | Ar[number]>
-    : Ar extends NonEmptyTuple<unknown>
-      ? NonEmptyArray<V | Ar[number]>
-      : readonly (V | Ar[number])[];
+): Readonly<{ [K in keyof Ar]: V | Ar[number] }>;
 
 // curried version
 export function toRangeFilled<const V>(
@@ -434,15 +445,12 @@ export function toRangeFilled<const V>(
     start: SizeType.ArgArrWithNegative,
     end: SizeType.ArgArrWithNegative,
   ],
-): <const Ar extends readonly unknown[]>(
+): (<const Ar extends readonly unknown[] & UnknownBrand>(
   array: Ar,
-) => HasLengthConstraint<Ar> extends true
-  ? ChangeArrayElement<Ar, V | Ar[number]>
-  : IsFixedLengthList<Ar> extends true
-    ? FixedLengthTuple<Ar['length'], V | Ar[number]>
-    : Ar extends NonEmptyTuple<unknown>
-      ? NonEmptyArray<V | Ar[number]>
-      : readonly (V | Ar[number])[];
+) => ChangeArrayElement<Ar, V | Ar[number]>) &
+  (<const Ar extends readonly unknown[]>(
+    array: Ar,
+  ) => Readonly<{ [K in keyof Ar]: V | Ar[number] }>);
 
 export function toRangeFilled<E, const V>(
   ...args:

--- a/packages/ts-data-forge/src/array/impl/array-utils-modification.test.mts
+++ b/packages/ts-data-forge/src/array/impl/array-utils-modification.test.mts
@@ -8,6 +8,7 @@ import {
 import { expectType } from '../../expect-type.mjs';
 import { asUint32 } from '../../number/index.mjs';
 import { type SizeType } from '../../types.mjs';
+import { asMinLengthArray } from './array-utils-length-bounded-array-cast.mjs';
 import {
   set,
   toFilled,
@@ -243,6 +244,45 @@ describe('Arr modifications', () => {
 
       assert.deepStrictEqual(result, [0, 0, 0]);
     });
+
+    test('should preserve the tuple shape under a generic parameter', () => {
+      // A caller that is itself generic over the tuple cannot resolve a
+      // conditional return type, so the unbranded overload has to state the
+      // homomorphic mapping directly.
+      const blank = <const T extends readonly number[]>(
+        xs: T,
+      ): Readonly<{ [K in keyof T]: 0 }> => toFilled(xs, 0);
+
+      const result = blank([1, 2, 3] as const);
+
+      expectType<typeof result, FixedLengthTuple<3, 0>>('=');
+
+      assert.deepStrictEqual<FixedLengthTuple<3, 0>>(result, [0, 0, 0]);
+    });
+
+    test('should preserve the tuple shape under a generic parameter when curried', () => {
+      const blank = <const T extends readonly number[]>(
+        xs: T,
+      ): Readonly<{ [K in keyof T]: 0 }> => toFilled(0)(xs);
+
+      const result = blank([1, 2] as const);
+
+      expectType<typeof result, FixedLengthTuple<2, 0>>('=');
+
+      assert.deepStrictEqual<FixedLengthTuple<2, 0>>(result, [0, 0]);
+    });
+
+    test('should keep the length brand of a branded array', () => {
+      const lower: MinLengthArray<2, number> = asMinLengthArray(2, [1, 2, 3]);
+
+      const filled = toFilled(lower, 0);
+
+      expectType<typeof filled, MinLengthArray<2, 0>>('~=');
+
+      // The brand is not part of the runtime value, so compare structurally —
+      // the type argument is what widens it, no intermediate binding needed.
+      assert.deepStrictEqual<readonly number[]>(filled, [0, 0, 0]);
+    });
   });
 
   describe(toRangeFilled, () => {
@@ -268,6 +308,18 @@ describe('Arr modifications', () => {
       const result = toRangeFilled(arr, 0, [2, 2]);
 
       assert.deepStrictEqual(result, [1, 2, 3]);
+    });
+
+    test('should preserve the tuple shape under a generic parameter', () => {
+      const blankMiddle = <const T extends readonly number[]>(
+        xs: T,
+      ): Readonly<{ [K in keyof T]: number }> => toRangeFilled(xs, 0, [1, 2]);
+
+      const result = blankMiddle([1, 2, 3] as const);
+
+      expectType<typeof result, FixedLengthTuple<3, number>>('=');
+
+      assert.deepStrictEqual<FixedLengthTuple<3, number>>(result, [1, 0, 3]);
     });
 
     test('should clamp range to array bounds', () => {

--- a/packages/ts-data-forge/src/array/impl/array-utils-shape-invariants.test.mts
+++ b/packages/ts-data-forge/src/array/impl/array-utils-shape-invariants.test.mts
@@ -1,0 +1,284 @@
+import {
+  type BoundedLengthArray,
+  type FixedLengthArray,
+  type FixedLengthTuple,
+  type MaxLengthArray,
+  type MaxLengthOf,
+  type MinLengthArray,
+  type MinLengthOf,
+} from 'ts-type-forge';
+import { expectType } from '../../expect-type.mjs';
+import {
+  asBoundedLengthArray,
+  asFixedLengthArray,
+  asMaxLengthArray,
+  asMinLengthArray,
+} from './array-utils-length-bounded-array-cast.mjs';
+import { toFilled, toRangeFilled } from './array-utils-modification.mjs';
+import { map, toReversed, toSorted } from './array-utils-transformation.mjs';
+
+/**
+ * Invariant-based coverage for the array -> array transforms.
+ *
+ * Rather than pinning an expected type for every (brand x shape x context)
+ * combination — which is a large table whose expected side is easy to derive
+ * from the implementation and therefore prove nothing — this asserts the small
+ * set of properties every shape-preserving transform must satisfy, across a
+ * fixed list of sample inputs that covers the axes.
+ *
+ * The properties are:
+ *
+ * 1. **Length** — the result reports the same `length` as the input.
+ * 2. **Bounds** — a length brand on the input survives onto the result.
+ * 3. **Generic context** — from a caller that is itself generic over the
+ *    array, the result is assignable to the caller's own homomorphic mapping.
+ *
+ * Property 3 is the one with no coverage before this file, and is what the
+ * `Arr.map` regression fixed in this PR violated: a conditional return type a
+ * generic `Ar` cannot decide stays deferred, and its brand-carrying branch is
+ * then not assignable to the caller's mapping.
+ */
+
+// The sample inputs. Between them they cover the axes: empty / singleton /
+// fixed tuple / non-empty tuple / unbounded array on the shape axis, and
+// unbranded / lower bound / upper bound / both / exact on the brand axis.
+const emptyTuple: readonly [] = [] as const;
+
+const singleton: readonly [1] = [1] as const;
+
+const fixedTuple: readonly [1, 2, 3] = [1, 2, 3] as const;
+
+const nonEmptyTuple: readonly [1, ...number[]] = [1, 2, 3] as const;
+
+const plainArray: readonly number[] = [1, 2, 3] as const;
+
+const lowerBounded: MinLengthArray<2, number> = asMinLengthArray(2, [1, 2, 3]);
+
+const upperBounded: MaxLengthArray<5, number> = asMaxLengthArray(5, [1, 2, 3]);
+
+const bounded: BoundedLengthArray<2, 5, number> = asBoundedLengthArray(
+  2,
+  5,
+  [1, 2, 3],
+);
+
+const exactLength: FixedLengthArray<3, number> = asFixedLengthArray(
+  3,
+  [1, 2, 3],
+);
+
+/**
+ * Property 3 — generic context.
+ *
+ * Each of these is an assertion by construction: the annotated return type is
+ * the caller's own homomorphic mapping, so the declaration only compiles while
+ * the transform reports something assignable to it. There is nothing to run.
+ *
+ * Only the transforms that satisfy this today are listed. `toSorted`,
+ * `toSortedBy`, `toReversed`, `toUpdated`, `tail`, `butLast` and `zip` do not
+ * yet — see the PR description for why each one resists the same fix. Add them
+ * here as they are fixed; that is what makes this list the coverage record.
+ */
+
+const mapInGenericContext = <const T extends readonly number[]>(
+  xs: T,
+): Readonly<{ [K in keyof T]: string }> => map(xs, String);
+
+const mapCurriedInGenericContext = <const T extends readonly number[]>(
+  xs: T,
+): Readonly<{ [K in keyof T]: string }> => map(String)(xs);
+
+const toFilledInGenericContext = <const T extends readonly number[]>(
+  xs: T,
+): Readonly<{ [K in keyof T]: 0 }> => toFilled(xs, 0);
+
+const toFilledCurriedInGenericContext = <const T extends readonly number[]>(
+  xs: T,
+): Readonly<{ [K in keyof T]: 0 }> => toFilled(0)(xs);
+
+const toRangeFilledInGenericContext = <const T extends readonly number[]>(
+  xs: T,
+): Readonly<{ [K in keyof T]: number }> => toRangeFilled(xs, 0, [0, 1]);
+
+describe('Arr shape invariants', () => {
+  // The type-level assertions below are checked by `tsc`; this pins the same
+  // property at runtime, so a transform that silently drops or adds an element
+  // fails here even where the type says otherwise.
+  test('every shape-preserving transform keeps the length at runtime', () => {
+    const input = [3, 1, 2] as const;
+
+    assert.deepStrictEqual<FixedLengthTuple<5, 3>>(
+      [
+        map(input, String).length,
+        toFilled(input, 0).length,
+        toRangeFilled(input, 0, [1, 2]).length,
+        toSorted(input).length,
+        toReversed(input).length,
+      ] as const,
+      [3, 3, 3, 3, 3] as const,
+    );
+  });
+
+  test('the generic-context callers agree with their annotations', () => {
+    const input = [3, 1, 2] as const;
+
+    assert.deepStrictEqual<FixedLengthTuple<3, string>>(
+      mapInGenericContext(input),
+      ['3', '1', '2'],
+    );
+
+    assert.deepStrictEqual<FixedLengthTuple<3, string>>(
+      mapCurriedInGenericContext(input),
+      ['3', '1', '2'],
+    );
+
+    assert.deepStrictEqual<FixedLengthTuple<3, 0>>(
+      toFilledInGenericContext(input),
+      [0, 0, 0],
+    );
+
+    assert.deepStrictEqual<FixedLengthTuple<3, 0>>(
+      toFilledCurriedInGenericContext(input),
+      [0, 0, 0],
+    );
+
+    assert.deepStrictEqual<FixedLengthTuple<3, number>>(
+      toRangeFilledInGenericContext(input),
+      [0, 1, 2],
+    );
+  });
+});
+
+// `map` — property 1 (length) across every unbranded sample.
+{
+  const _a = map(emptyTuple, String);
+
+  const _b = map(singleton, String);
+
+  const _c = map(fixedTuple, String);
+
+  const _d = map(nonEmptyTuple, String);
+
+  const _e = map(plainArray, String);
+
+  expectType<(typeof _a)['length'], (typeof emptyTuple)['length']>('=');
+
+  expectType<(typeof _b)['length'], (typeof singleton)['length']>('=');
+
+  expectType<(typeof _c)['length'], (typeof fixedTuple)['length']>('=');
+
+  expectType<(typeof _d)['length'], (typeof nonEmptyTuple)['length']>('=');
+
+  expectType<(typeof _e)['length'], (typeof plainArray)['length']>('=');
+}
+
+// `map` — property 2 (bounds) across every branded sample.
+{
+  const _a = map(lowerBounded, String);
+
+  const _b = map(upperBounded, String);
+
+  const _c = map(bounded, String);
+
+  const _d = map(exactLength, String);
+
+  expectType<MinLengthOf<typeof _a>, MinLengthOf<typeof lowerBounded>>('=');
+
+  expectType<MaxLengthOf<typeof _b>, MaxLengthOf<typeof upperBounded>>('=');
+
+  expectType<MinLengthOf<typeof _c>, MinLengthOf<typeof bounded>>('=');
+
+  expectType<MaxLengthOf<typeof _c>, MaxLengthOf<typeof bounded>>('=');
+
+  expectType<MinLengthOf<typeof _d>, MinLengthOf<typeof exactLength>>('=');
+
+  expectType<MaxLengthOf<typeof _d>, MaxLengthOf<typeof exactLength>>('=');
+}
+
+// `toFilled` — properties 1 and 2.
+{
+  const _a = toFilled(fixedTuple, 0);
+
+  const _b = toFilled(nonEmptyTuple, 0);
+
+  const _c = toFilled(plainArray, 0);
+
+  const _d = toFilled(lowerBounded, 0);
+
+  const _e = toFilled(bounded, 0);
+
+  expectType<(typeof _a)['length'], (typeof fixedTuple)['length']>('=');
+
+  expectType<(typeof _b)['length'], (typeof nonEmptyTuple)['length']>('=');
+
+  expectType<(typeof _c)['length'], (typeof plainArray)['length']>('=');
+
+  expectType<MinLengthOf<typeof _d>, MinLengthOf<typeof lowerBounded>>('=');
+
+  expectType<MinLengthOf<typeof _e>, MinLengthOf<typeof bounded>>('=');
+
+  expectType<MaxLengthOf<typeof _e>, MaxLengthOf<typeof bounded>>('=');
+}
+
+// `toRangeFilled` — properties 1 and 2.
+{
+  const _a = toRangeFilled(fixedTuple, 0, [1, 2]);
+
+  const _b = toRangeFilled(plainArray, 0, [0, 1]);
+
+  const _c = toRangeFilled(lowerBounded, 0, [0, 1]);
+
+  expectType<(typeof _a)['length'], (typeof fixedTuple)['length']>('=');
+
+  expectType<(typeof _b)['length'], (typeof plainArray)['length']>('=');
+
+  expectType<MinLengthOf<typeof _c>, MinLengthOf<typeof lowerBounded>>('=');
+}
+
+// `toSorted` — properties 1 and 2. Sorting neither adds nor drops elements, so
+// it is held to the same contract even though it is not fixed for property 3.
+{
+  const _a = toSorted(fixedTuple);
+
+  const _b = toSorted(nonEmptyTuple);
+
+  const _c = toSorted(plainArray);
+
+  const _d = toSorted(lowerBounded);
+
+  const _e = toSorted(bounded);
+
+  expectType<(typeof _a)['length'], (typeof fixedTuple)['length']>('=');
+
+  expectType<(typeof _b)['length'], (typeof nonEmptyTuple)['length']>('=');
+
+  expectType<(typeof _c)['length'], (typeof plainArray)['length']>('=');
+
+  expectType<MinLengthOf<typeof _d>, MinLengthOf<typeof lowerBounded>>('=');
+
+  expectType<MinLengthOf<typeof _e>, MinLengthOf<typeof bounded>>('=');
+
+  expectType<MaxLengthOf<typeof _e>, MaxLengthOf<typeof bounded>>('=');
+}
+
+// `toReversed` — properties 1 and 2. Reversal permutes, so the length and the
+// bounds are exactly what must not move.
+{
+  const _a = toReversed(fixedTuple);
+
+  const _b = toReversed(plainArray);
+
+  const _c = toReversed(lowerBounded);
+
+  const _d = toReversed(bounded);
+
+  expectType<(typeof _a)['length'], (typeof fixedTuple)['length']>('=');
+
+  expectType<(typeof _b)['length'], (typeof plainArray)['length']>('=');
+
+  expectType<MinLengthOf<typeof _c>, MinLengthOf<typeof lowerBounded>>('=');
+
+  expectType<MinLengthOf<typeof _d>, MinLengthOf<typeof bounded>>('=');
+
+  expectType<MaxLengthOf<typeof _d>, MaxLengthOf<typeof bounded>>('=');
+}

--- a/packages/ts-data-forge/src/array/impl/array-utils-transformation.mts
+++ b/packages/ts-data-forge/src/array/impl/array-utils-transformation.mts
@@ -12,6 +12,7 @@ import {
   type Primitive,
   type SafeUintWithSmallInt,
   type SupportedLength,
+  type UnknownBrand,
   type WithSmallInt,
 } from 'ts-type-forge';
 import { IMap } from '../../collections/index.mjs';
@@ -46,15 +47,41 @@ import { size } from './array-utils-size.mjs';
  * assert.deepStrictEqual(indexed, ['0:1', '1:2', '2:3']);
  * ```
  */
-export function map<const Ar extends readonly unknown[], B>(
+export function map<const Ar extends readonly unknown[] & UnknownBrand, B>(
   array: Ar,
   mapFn: (a: Ar[number], index: ArrayIndex<Ar>) => B,
 ): ChangeArrayElement<Ar, B>;
 
+// A plain array or tuple carries no length brand, so the homomorphic mapping
+// is the whole answer. Stating it directly — rather than going through
+// `ChangeArrayElement`, whose `HasLengthConstraint` test a *generic* `Ar`
+// cannot decide — is what keeps `map` usable inside a function that is itself
+// generic over the tuple: a deferred conditional is not assignable to the
+// caller's own `{ [K in keyof Ar]: B }`, while this is.
+export function map<const Ar extends readonly unknown[], B>(
+  array: Ar,
+  mapFn: (a: Ar[number], index: ArrayIndex<Ar>) => B,
+): Readonly<{ [K in keyof Ar]: B }>;
+
 // curried version
+//
+// The two cases have to be overloads *of the returned function*, not two
+// overloads of `map` itself: both curried signatures take the same single
+// argument, so overload resolution would always pick the first and the second
+// would be dead.
+//
+// Spelled as an intersection of two function types rather than one object type
+// carrying two call signatures — the `convert-to-readonly` codemod wraps an
+// inline object type in `Readonly<…>`, and a mapped type drops call
+// signatures, which would leave the curried form with none at all.
 export function map<A, B>(
   mapFn: (a: A, index: SizeType.Arr) => B,
-): <const Ar extends readonly A[]>(array: Ar) => ChangeArrayElement<Ar, B>;
+): (<const Ar extends readonly A[] & UnknownBrand>(
+  array: Ar,
+) => ChangeArrayElement<Ar, B>) &
+  (<const Ar extends readonly A[]>(
+    array: Ar,
+  ) => Readonly<{ [K in keyof Ar]: B }>);
 
 export function map<A, B>(
   ...args:

--- a/packages/ts-data-forge/src/array/impl/array-utils-transformation.test.mts
+++ b/packages/ts-data-forge/src/array/impl/array-utils-transformation.test.mts
@@ -9,6 +9,7 @@ import { IMap } from '../../collections/index.mjs';
 import { expectType } from '../../expect-type.mjs';
 import { Optional } from '../../functional/index.mjs';
 import { SafeUint } from '../../number/index.mjs';
+import { asMinLengthArray } from './array-utils-length-bounded-array-cast.mjs';
 import {
   cartesianProduct,
   concat,
@@ -66,6 +67,33 @@ describe('Arr transformations', () => {
       expectType<typeof mappedWithIndex, FixedLengthTuple<3, string>>('<=');
 
       assert.deepStrictEqual(mappedWithIndex, ['0:a', '1:b', '2:c']);
+    });
+
+    test('should preserve the tuple shape under a generic parameter', () => {
+      // A caller that is itself generic over the tuple cannot resolve a
+      // conditional return type, so `map` has to report the homomorphic
+      // mapping directly for a parameter that carries no length brand.
+      const mapValues = <const T extends readonly Readonly<{ v: unknown }>[]>(
+        boxes: T,
+      ): Readonly<{ [K in keyof T]: unknown }> => map(boxes, (b) => b.v);
+
+      const result = mapValues([{ v: 1 }, { v: 'a' }] as const);
+
+      expectType<typeof result, FixedLengthTuple<2, unknown>>('=');
+
+      assert.deepStrictEqual<FixedLengthTuple<2, unknown>>(result, [1, 'a']);
+    });
+
+    test('should keep the length brand of a branded array', () => {
+      const lower: MinLengthArray<2, number> = asMinLengthArray(2, [1, 2, 3]);
+
+      const mappedLower = map(lower, String);
+
+      expectType<typeof mappedLower, MinLengthArray<2, string>>('~=');
+
+      // The brand is not part of the runtime value, so compare structurally —
+      // the type argument is what widens it, no intermediate binding needed.
+      assert.deepStrictEqual<readonly string[]>(mappedLower, ['1', '2', '3']);
     });
   });
 


### PR DESCRIPTION
> Note: GitHub strips `<` followed by a letter from issue bodies, even inside code fences, so the type-parameter lists below are written with a space after `<`. They are still valid TypeScript.

## Summary

Fixes a v14 regression: transforming a tuple into a same-length tuple stopped working inside a function that is itself **generic** over the tuple.

```ts
type Box = Readonly<{ v: unknown }>;

const mapValues = < const T extends readonly Box[] >(
  boxes: T,
): Readonly<{ [K in keyof T]: unknown }> => Arr.map(boxes, (b) => b.v);
//                                          ^ TS2322 before this PR
```

Reported from ts-fortress, whose `array/tuple.mts` had to add `total-functions/no-unsafe-type-assertion` and a cast to `MapTuple` to work around it.

## Cause

[#469](https://github.com/noshiro-pf/ts-data-forge/pull/469) changed these return types to branch on `HasLengthConstraint`. That is the right thing for a brand-carrying array — a homomorphic mapped type over a length-branded array maps `length`, the array methods *and* the brand keys, producing a non-array object.

But a **generic** `Ar` cannot decide that test. The conditional stays deferred, and its brand-carrying branch is not assignable to the caller's own mapping — the reported error is that `ChangeArrayElement` of `T` is not assignable to `Readonly<{ [K in keyof T]: unknown }>`, because the union it resolves to still contains the `ConstrainedStructureOf` intersected with the brand.

No reformulation of the *predicate* helps — TypeScript keeps both branches for a generic parameter regardless of how the test is written, which was verified against several spellings. A conditional return type simply cannot work here; the pre-v14 signatures worked precisely because they were unconditional.

Concrete tuples were never affected: there `HasLengthConstraint` resolves to `false` and the homomorphic branch is taken. The existing assertion that mapping a three-tuple yields a `FixedLengthTuple` of length 3 held throughout.

## Fix

`map`, `toFilled` and `toRangeFilled` each become a pair of overloads:

- an array carrying a length brand selects the first and still gets `ChangeArrayElement`;
- everything else selects the second, which states the homomorphic mapping directly — no conditional to defer.

`UnknownBrand` separates them: the length brands satisfy it, a plain array or tuple does not.

```ts
export function map< const Ar extends readonly unknown[] & UnknownBrand, B >(
  array: Ar,
  mapFn: (a: Ar[number], index: ArrayIndex<Ar>) => B,
): ChangeArrayElement<Ar, B>;

export function map< const Ar extends readonly unknown[], B >(
  array: Ar,
  mapFn: (a: Ar[number], index: ArrayIndex<Ar>) => B,
): Readonly<{ [K in keyof Ar]: B }>;
```

For `toFilled` / `toRangeFilled` this also collapses the three unbranded branches the conditional spelled out — a fixed-length tuple keeps its length, a non-empty tuple stays non-empty and a plain array stays unbounded, all of which the homomorphic mapping already says.

The curried forms need the two cases as overloads of the **returned** function, because both curried signatures take the same single argument and overload resolution would always pick the first, leaving the second dead. They are spelled as an intersection of two function types rather than one object type with two call signatures: the `convert-to-readonly` codemod wraps an inline object type in `Readonly`, and a mapped type drops call signatures — which would leave the curried form with no call signature at all, and only *after* the codemod runs, i.e. past `ws:tsc`.

## Not fixed here

Surveying the rest of `Arr` for the same shape-preserving contract found six more functions that do not resolve under a generic array parameter. They split into two groups:

| function | why |
| :-- | :-- |
| `toSorted`, `toSortedBy` | same root cause, but their *parameter* type is itself a conditional. Converting them to overloads makes the overload/implementation compatibility check fail (TS2394), which relaxing the implementation signature does not resolve — the argument handling has to be redesigned too |
| `toReversed` | `ConstrainedList.Reverse` defers, and splitting by brand does not help: reversing a tuple of unknown length is only expressible recursively |
| `toUpdated` | `ConstrainedList.SetAt` defers, plus TS2589 (instantiation depth) |
| `tail`, `butLast`, `zip` | TS2590 — the union becomes too complex to represent, i.e. the type computation itself breaks down rather than merely deferring |

The last group is an instantiation-budget problem rather than a deferral one, so it is deliberately left for separate work. All six are called out in the changeset.

## Tests

Two layers.

**Per-function assertions**, next to each function's existing tests: the generic-parameter shape for `map`, `toFilled` (direct and curried) and `toRangeFilled`, plus branded inputs for `map` and `toFilled` asserting the brand still survives.

**Invariant coverage** — a new `array-utils-shape-invariants.test.mts` that holds every array → array transform to the properties that must survive any change to how the return type is spelled, rather than pinning an expected type per combination (a table whose expected side is derived from the implementation proves nothing):

1. **Length** — the result reports the same `length` as the input.
2. **Bounds** — a length brand on the input survives onto the result.
3. **Generic context** — from a caller itself generic over the array, the result is assignable to the caller's own homomorphic mapping.

The samples cover the shape axis (empty / singleton / fixed tuple / non-empty tuple / unbounded array) and the brand axis (none / lower / upper / bounded / exact). Properties 1 and 2 are asserted for `toSorted` and `toReversed` too — they satisfy those even though they fail property 3.

Property 3 is what had no coverage at all, and is exactly what this regression violated. It is asserted **by construction**: each generic-context caller only compiles while the transform reports something assignable to its annotation, so that list of callers doubles as the coverage record — the seven functions above are absent because they do not satisfy it yet, and adding one there is the last step of fixing it.

The samples are real values rather than `declare const`, because the assertions sit at module top level and a declaration with no runtime binding makes importing the file throw. Two runtime tests pin the same length property and exercise the generic-context callers, so a transform that silently drops an element fails even where the type says otherwise.

## Effect on ts-fortress

Verified against a local build injected into ts-fortress: `array/tuple.mts` type-checks with **both** casts and their `no-unsafe-type-assertion` disables removed entirely.

Its `@typescript-eslint/no-unsafe-return` disables still apply — those come from `AnyType`'s payload being `any`, which is independent of `Arr.map`.

## Verification

`ws:tsc`, `ws:test` (856 + 19 files), `ws:lint:fix` (0 errors), `codemod:full`, the three doc-embed steps, `fmt:full`, `cspell`, `md`, `check:root` and `ws:build` all pass with a clean working tree, and the sequence reaches a fixed point on a second run.